### PR TITLE
Wrong URL to Tollgate Installer Repo

### DIFF
--- a/docs/releasenotes/v0.0.3_release_notes.md
+++ b/docs/releasenotes/v0.0.3_release_notes.md
@@ -60,7 +60,7 @@ If you are already running v0.0.2 of TollGate Module Basic Go, the JANITOR servi
 
 For new installations or manual updates, use the TollGate Installer to get the latest TollGateOS:
 
-1. Visit the [TollGate Installer](https://github.com/OpenTollGate/installer) repository
+1. Visit the [TollGate Installer](https://github.com/OpenTollGate/tollgate-installer) repository
 2. Follow the installation instructions for your specific router hardware
 3. The installer will configure the entire TollGateOS system, which includes the TollGate Module Basic Go v0.0.3
 4. After installation, you'll need to configure your profit sharing settings as described in the Configuration Example section below


### PR DESCRIPTION
While reviewing the release notes, I noticed that the link to the installer is incorrect.

This is my first pull request on GitHub — I hope I'm doing everything correctly.

Greetings
Thomas