### PR TITLE
v0.3.0

### DIFF
--- a/files/etc/tollgate/release.json
+++ b/files/etc/tollgate/release.json
@@ -9,24 +9,24 @@
           "version": "0.0.1",
           "architectures": {
             "aarch64_cortex-a53": {
-              "url": "https://blossom.swissdash.site/405690e01d31d579a05f33bffe7222335e402ab8f21fe9b13ec1b75cca3d77e7.ipk",
-              "hash": "sha256:405690e01d31d579a05f33bffe7222335e402ab8f21fe9b13ec1b75cca3d77e7",
-              "eventId": "94570ce33f8761364d6a6e20d9681238f644293f6aed155e66d1cebf7b3bd66f"
+              "url": "https://blossom.swissdash.site/d39be9e533cc58886d80185c3e3d0c19e0cfa25a445e80580220524acc6d98c5.ipk",
+              "hash": "sha256:d39be9e533cc58886d80185c3e3d0c19e0cfa25a445e80580220524acc6d98c5",
+              "eventId": "6e2e25f9e5bf128722d43064dde87ea3f7daa57d59c8c62172ff08808ba0a16a"
             },
             "mipsel_24kc": {
-              "url": "https://blossom.swissdash.site/546b3fbb3f481184b366e3e1315eaba182af2033a13eedbea4c2223c1986a1bc.ipk",
-              "hash": "sha256:546b3fbb3f481184b366e3e1315eaba182af2033a13eedbea4c2223c1986a1bc",
-              "eventId": "fed09af856d08fb8e4005683db2624b90e509af13e5a93c9dc139a99670ed55e"
+              "url": "https://blossom.swissdash.site/18d697b0b570a4ba85687a2ec2c587f364a21c4605bc13f4112784618ede7c7e.ipk",
+              "hash": "sha256:18d697b0b570a4ba85687a2ec2c587f364a21c4605bc13f4112784618ede7c7e",
+              "eventId": "dacf3fe493e3978623486de651d261b758a19b2a6d1c9652bc8cc288efd031d9"
             },
             "mips_24kc": {
-              "url": "https://blossom.swissdash.site/91be25ac2688b5747acbeb0ef29604034ff16751a65df265164a778db04d5d1b.ipk",
-              "hash": "sha256:91be25ac2688b5747acbeb0ef29604034ff16751a65df265164a778db04d5d1b",
-              "eventId": "c14db016042c4635b8e5b9d198c6d791345363599e23762280838e792dd71243"
+              "url": "https://blossom.swissdash.site/5b4d3c92fc4abf4848f47c6be8914906070f582fe9c67f7d12fc36e8215ae7ca.ipk",
+              "hash": "sha256:5b4d3c92fc4abf4848f47c6be8914906070f582fe9c67f7d12fc36e8215ae7ca",
+              "eventId": "118aa8bcbe9a5a7b71d25db738f58f21ff53ca8f125bdcd80213c52f799f8969"
             },
             "arm_cortex-a7": {
-              "url": "https://blossom.swissdash.site/1f08a3708919e8fd81b8cefe32796c36a85aeb5cc4c9f5adb8250a651839b255.ipk",
-              "hash": "sha256:1f08a3708919e8fd81b8cefe32796c36a85aeb5cc4c9f5adb8250a651839b255",
-              "eventId": "e751d3d035328290604a76a289efa22ca6c4d48a5e1835846b6ec8568f155384"
+              "url": "https://blossom.swissdash.site/55458bcb26e1fa3dd2ab5cb84ea7a00c7b3a93808d3bacfab85605fdb573d627.ipk",
+              "hash": "sha256:55458bcb26e1fa3dd2ab5cb84ea7a00c7b3a93808d3bacfab85605fdb573d627",
+              "eventId": "402611d13c082268f2d10d1ff97f2801b01757ceb8627cde6a11a48ba8704c7c"
             },
             "arm64_cortex-a53": {
               "url": "https://blossom.swissdash.site/73f0ade7daf36405e580cb7ceb8bbd93f8b35b4b74209bdd5b70eea23ffeb962.ipk",
@@ -34,9 +34,9 @@
               "eventId": "95726da9aed6fa93d2ba72ecb77de95b4b1910cade1b6c2dcd854ff5c56bd7c6"
             },
             "aarch64_cortex-a72": {
-              "url": "https://blossom.swissdash.site/e63645dbeed97a08fd9ada5168be372def029bb03d4da4742ab9fc7fb77a09f1.ipk",
-              "hash": "sha256:e63645dbeed97a08fd9ada5168be372def029bb03d4da4742ab9fc7fb77a09f1",
-              "eventId": "5f89638aaf7d78ebfb02a29e71fc8ab8dcf154dae83428eba2c448415b7a0321"
+              "url": "https://blossom.swissdash.site/0c34cca8bb5726160b9623f288733c4625a1540dabcba36c7496e26dbeb77b90.ipk",
+              "hash": "sha256:0c34cca8bb5726160b9623f288733c4625a1540dabcba36c7496e26dbeb77b90",
+              "eventId": "f3b6f180a9a577aa548773858b7ddd352c7112b36a5a9c0bd189aff46feb96bd"
             }
           },
           "dependencies": []

--- a/files/etc/tollgate/release.json
+++ b/files/etc/tollgate/release.json
@@ -9,24 +9,24 @@
           "version": "0.0.1",
           "architectures": {
             "aarch64_cortex-a53": {
-              "url": "https://blossom.swissdash.site/2c0ddb79cf698744ca973f0a54dfc81d96ffc011dcd6f01c2b6c9b460da5d1d8.ipk",
-              "hash": "sha256:2c0ddb79cf698744ca973f0a54dfc81d96ffc011dcd6f01c2b6c9b460da5d1d8",
-              "eventId": "36a9d35986e47d8b24a3f41d82fdedac344571a2a0b5e06b0216f17b82e5b3f2"
+              "url": "https://blossom.swissdash.site/427bf4cf7800f4b9680d5a73f6c652938dda55adc8d47a9dd2996388d31d9263.ipk",
+              "hash": "sha256:427bf4cf7800f4b9680d5a73f6c652938dda55adc8d47a9dd2996388d31d9263",
+              "eventId": "3741822787976e0d8db3eae552b92cf46f2ef1eb7c44b3c836b4525999945c7c"
             },
             "mipsel_24kc": {
-              "url": "https://blossom.swissdash.site/8aaa62f292c67db870b06a964c154b3a0ea80e5008888122999623da9ec4b8fe.ipk",
-              "hash": "sha256:8aaa62f292c67db870b06a964c154b3a0ea80e5008888122999623da9ec4b8fe",
-              "eventId": "cb5381ff20eddcb90fffbd21a049015289dfe748af19074c86d7e4cb8556df79"
+              "url": "https://blossom.swissdash.site/5c258d55517704c68b7c2ac4a1cf27da1acd12a9432157dcf1d372d3b8a8a514.ipk",
+              "hash": "sha256:5c258d55517704c68b7c2ac4a1cf27da1acd12a9432157dcf1d372d3b8a8a514",
+              "eventId": "fba71f406b7e8655f25642403611d4cabea010edd20ae4bab57719117fe2ad2e"
             },
             "mips_24kc": {
-              "url": "https://blossom.swissdash.site/9f3db0e8adc00f2fad0902922a9072269d69951856e37b8cb1da6bb9d0555096.ipk",
-              "hash": "sha256:9f3db0e8adc00f2fad0902922a9072269d69951856e37b8cb1da6bb9d0555096",
-              "eventId": "4aceddd8c6530de777be2d6ff67f7887e99c2c5606638c1956429b4a5650dfee"
+              "url": "https://blossom.swissdash.site/46daa5db18685c4b126b652ebe12090d3a76a90e1e37ad7f325af5da20ab4083.ipk",
+              "hash": "sha256:46daa5db18685c4b126b652ebe12090d3a76a90e1e37ad7f325af5da20ab4083",
+              "eventId": "780fa3358e9f94d6f1ced7ec65f574aefee4ca1308e8bd7e2210f79a23ecd707"
             },
             "arm_cortex-a7": {
-              "url": "https://blossom.swissdash.site/b7f8188b719c963d8d15a2e9da32905e3485809e99598326e03e86ab20e10454.ipk",
-              "hash": "sha256:b7f8188b719c963d8d15a2e9da32905e3485809e99598326e03e86ab20e10454",
-              "eventId": "07ed8a3d9926cb8832d56552288c76fb94a2f3e8241ee06b779932a6d144813f"
+              "url": "https://blossom.swissdash.site/96dfda781d65832192f373a50352c0e5805f5afb71bd0def3913d7b4dad2acb7.ipk",
+              "hash": "sha256:96dfda781d65832192f373a50352c0e5805f5afb71bd0def3913d7b4dad2acb7",
+              "eventId": "5945144d728469447293cf755943e21cee88eb18cf32e7dedb092080a72fe917"
             },
             "arm64_cortex-a53": {
               "url": "https://blossom.swissdash.site/73f0ade7daf36405e580cb7ceb8bbd93f8b35b4b74209bdd5b70eea23ffeb962.ipk",
@@ -34,9 +34,9 @@
               "eventId": "95726da9aed6fa93d2ba72ecb77de95b4b1910cade1b6c2dcd854ff5c56bd7c6"
             },
             "aarch64_cortex-a72": {
-              "url": "https://blossom.swissdash.site/7e431b59496569c58d902ac0feef183dd08a4dbd387cfa52b733b781334802c5.ipk",
-              "hash": "sha256:7e431b59496569c58d902ac0feef183dd08a4dbd387cfa52b733b781334802c5",
-              "eventId": "c5362ca8171179293cb9cd9554f74fa3257a4c808eb4a61c24edd97ac306f3e1"
+              "url": "https://blossom.swissdash.site/c680b3be63396970c8787148a4d83096a19cbe143cd5abd366750e115d0f5062.ipk",
+              "hash": "sha256:c680b3be63396970c8787148a4d83096a19cbe143cd5abd366750e115d0f5062",
+              "eventId": "c6cdf9cc58bac4e3c13ceb0281716e55a509f13d12b537074dc32aff26541272"
             }
           },
           "dependencies": []

--- a/files/etc/tollgate/release.json
+++ b/files/etc/tollgate/release.json
@@ -9,24 +9,24 @@
           "version": "0.0.1",
           "architectures": {
             "aarch64_cortex-a53": {
-              "url": "https://blossom.swissdash.site/7ed3df4d4b8defbe21da0946f37be34ffc4d25c726a545ab7d8f908c0cb2a82e.ipk",
-              "hash": "sha256:7ed3df4d4b8defbe21da0946f37be34ffc4d25c726a545ab7d8f908c0cb2a82e",
-              "eventId": "bd069fdb01a639084e25e447187a556760bfb077d6cc29c2a4990d706d7369e2"
+              "url": "https://blossom.swissdash.site/8710737bf67b90518b480f9ffa5b55aaa7bf397169074c389c7905b680f70459.ipk",
+              "hash": "sha256:8710737bf67b90518b480f9ffa5b55aaa7bf397169074c389c7905b680f70459",
+              "eventId": "3a615d238fb795c58d4b9f96c24b5b5d174b355cb8cf86e884982a1bc76746f7"
             },
             "mipsel_24kc": {
-              "url": "https://blossom.swissdash.site/4de4981964ad98d408804ebeba552034ce34d375cc498c24b7b0c8c54788cbdd.ipk",
-              "hash": "sha256:4de4981964ad98d408804ebeba552034ce34d375cc498c24b7b0c8c54788cbdd",
-              "eventId": "17140dd340aa5cc7852e9e97a77959b1a5c4b31a92b91089deb36256d2446120"
+              "url": "https://blossom.swissdash.site/d335395d05de4240b0d3c4707136fc9fddfb352dc47a7281db67f64c91de680e.ipk",
+              "hash": "sha256:d335395d05de4240b0d3c4707136fc9fddfb352dc47a7281db67f64c91de680e",
+              "eventId": "1151fae2229fdb5258d32a19a1fc3620dec836673c3c2911557d07bdb571ebff"
             },
             "mips_24kc": {
-              "url": "https://blossom.swissdash.site/f6d58bb24c67fd9c2ceb37dfd61b78b003a6baf3daff91e07a3859e80d69b53c.ipk",
-              "hash": "sha256:f6d58bb24c67fd9c2ceb37dfd61b78b003a6baf3daff91e07a3859e80d69b53c",
-              "eventId": "932965da2ec7406036942a45620d7cda44b5eef559ded11e123afe54ada2fb78"
+              "url": "https://blossom.swissdash.site/cf7c6272e57415d13efb4b48df3d86d79767c32a1ef2186466024abbbf2235f0.ipk",
+              "hash": "sha256:cf7c6272e57415d13efb4b48df3d86d79767c32a1ef2186466024abbbf2235f0",
+              "eventId": "683dfe0aca3eb041135a17f9122421bffa8d2f88cdfde068495548bc7c4802a9"
             },
             "arm_cortex-a7": {
-              "url": "https://blossom.swissdash.site/7318e3d7bb31222c0415e5ccc1f6775f1cef4a8467732ac2e67d0c74fe2404e8.ipk",
-              "hash": "sha256:7318e3d7bb31222c0415e5ccc1f6775f1cef4a8467732ac2e67d0c74fe2404e8",
-              "eventId": "7171497749058c2db1b01fe7f04d84bd455948643b6b4b3752a8cc0427abccfa"
+              "url": "https://blossom.swissdash.site/5fc4635784a532033c5331231b539408a0d414ad381370df85d66cf5180c8a2b.ipk",
+              "hash": "sha256:5fc4635784a532033c5331231b539408a0d414ad381370df85d66cf5180c8a2b",
+              "eventId": "4d8b28cf9e5e0773b59bc84b05b2ec3241ebe6eb9ba1e9f560a5e74d5ea25744"
             },
             "arm64_cortex-a53": {
               "url": "https://blossom.swissdash.site/73f0ade7daf36405e580cb7ceb8bbd93f8b35b4b74209bdd5b70eea23ffeb962.ipk",
@@ -34,9 +34,9 @@
               "eventId": "95726da9aed6fa93d2ba72ecb77de95b4b1910cade1b6c2dcd854ff5c56bd7c6"
             },
             "aarch64_cortex-a72": {
-              "url": "https://blossom.swissdash.site/79980124c0e09e3cf11a4457194a8f9969e62b3f90a60918fd7871aa5da6c590.ipk",
-              "hash": "sha256:79980124c0e09e3cf11a4457194a8f9969e62b3f90a60918fd7871aa5da6c590",
-              "eventId": "ccc31cb0f0b1bb621434a9b6ad78e7c76121f661b4c30784599cb2a3a61fa0b6"
+              "url": "https://blossom.swissdash.site/eee36538159682456c5eb6c63bf54a9e6f4b41914cf8c91df6d76726a62f540d.ipk",
+              "hash": "sha256:eee36538159682456c5eb6c63bf54a9e6f4b41914cf8c91df6d76726a62f540d",
+              "eventId": "48d352710f2be34f2ec1913be0fc234753f1bc5366b41b034774f72aca8bf39f"
             }
           },
           "dependencies": []

--- a/files/etc/tollgate/release.json
+++ b/files/etc/tollgate/release.json
@@ -9,24 +9,24 @@
           "version": "0.0.1",
           "architectures": {
             "aarch64_cortex-a53": {
-              "url": "https://blossom.swissdash.site/cbf390c65a4b86da6d6adbab55b806ffc368ff2acf718c7837277e876a773dfb.ipk",
-              "hash": "sha256:cbf390c65a4b86da6d6adbab55b806ffc368ff2acf718c7837277e876a773dfb",
-              "eventId": "05a1385ea2efe7846d3f41b0c2fae2f09baaffa30d8c2774f1f3d916957e4865"
+              "url": "https://blossom.swissdash.site/6e43ff301370316dc2abb79d0879ab036a4c54ea048d23727207b4f264d2839f.ipk",
+              "hash": "sha256:6e43ff301370316dc2abb79d0879ab036a4c54ea048d23727207b4f264d2839f",
+              "eventId": "a52941831a59cbc614c603acbc6f3b0c53eaf5bc521a3cd0687c277c0de21f55"
             },
             "mipsel_24kc": {
-              "url": "https://blossom.swissdash.site/8b33ec3c3a7040709909268904af1199276750373854988b195a6e413d2c18cd.ipk",
-              "hash": "sha256:8b33ec3c3a7040709909268904af1199276750373854988b195a6e413d2c18cd",
-              "eventId": "8af4de5ab1389759edb6ae84391ef3a9bb0eaa9f7a6047730757d7e81692eaf3"
+              "url": "https://blossom.swissdash.site/595639c9ef284d51e26bc5a6e8eee7eb91aab9836edd1f60f1f38f19d103255a.ipk",
+              "hash": "sha256:595639c9ef284d51e26bc5a6e8eee7eb91aab9836edd1f60f1f38f19d103255a",
+              "eventId": "ac34c39c4c8fc45c9994b554880c458ba76f386dee92142253ceed2823adcb0f"
             },
             "mips_24kc": {
-              "url": "https://blossom.swissdash.site/7be6695f7d33831dbd214fbafef386709c6d26868d5b68d61eea919fb0ecfdef.ipk",
-              "hash": "sha256:7be6695f7d33831dbd214fbafef386709c6d26868d5b68d61eea919fb0ecfdef",
-              "eventId": "57a24e427b834db942666d1c238b14147feaef8012e1d9a72d7ba2c6c87d6b1d"
+              "url": "https://blossom.swissdash.site/49f3b7167273844a91d5c451b85a13d98efc7180d9fc0b4824a40d7de861f3d0.ipk",
+              "hash": "sha256:49f3b7167273844a91d5c451b85a13d98efc7180d9fc0b4824a40d7de861f3d0",
+              "eventId": "980dbd63b57e37ba2bbfdfdabf285a45bb3cc66058f3acfd05cb3188e03352dd"
             },
             "arm_cortex-a7": {
-              "url": "https://blossom.swissdash.site/c95e49697f3de7e60b3d63ac00b79fe14b6385827410f998b32126526edd04b5.ipk",
-              "hash": "sha256:c95e49697f3de7e60b3d63ac00b79fe14b6385827410f998b32126526edd04b5",
-              "eventId": "8c806949dfe4049eaca2a4487bdb8592ef6bed583fcc2ffceb636d9fc97c5f7b"
+              "url": "https://blossom.swissdash.site/53168c2378fb7723b8b82abd4679b1a8a424c133ff6087de0bf353c934d08c29.ipk",
+              "hash": "sha256:53168c2378fb7723b8b82abd4679b1a8a424c133ff6087de0bf353c934d08c29",
+              "eventId": "a937947239000ca103fcfe47c14f67127793c3708376b8d8b2f1579b3420acaa"
             },
             "arm64_cortex-a53": {
               "url": "https://blossom.swissdash.site/73f0ade7daf36405e580cb7ceb8bbd93f8b35b4b74209bdd5b70eea23ffeb962.ipk",
@@ -34,9 +34,9 @@
               "eventId": "95726da9aed6fa93d2ba72ecb77de95b4b1910cade1b6c2dcd854ff5c56bd7c6"
             },
             "aarch64_cortex-a72": {
-              "url": "https://blossom.swissdash.site/e8362180b67e6999079e7dbf760f68342b6ef6d922dd523046f36dc54cc7e361.ipk",
-              "hash": "sha256:e8362180b67e6999079e7dbf760f68342b6ef6d922dd523046f36dc54cc7e361",
-              "eventId": "b8893136050433357585e6264c0fe15f43ca7547f3a35d09dde168f43357e4ef"
+              "url": "https://blossom.swissdash.site/39aed3a2c3e443571e32a895e2f86460ca436bc6eeddbbf5eaae4bf9592d6788.ipk",
+              "hash": "sha256:39aed3a2c3e443571e32a895e2f86460ca436bc6eeddbbf5eaae4bf9592d6788",
+              "eventId": "7e83eff04da76859637333945722f89a9af1f140f4c0b8cd29c7b9af3410d1ec"
             },
             "x86_64": {
               "url": "https://blossom.swissdash.site/993aaea07198664c4da5f8dc3437514a015a6c5e488ecf43227ba0d9af5613fe.ipk",
@@ -72,6 +72,31 @@
               "url": "https://blossom.swissdash.site/4b3995b1b0b414f29748e43e3ba90d603d760acef84c71a65b1f05c9b31642d8.ipk",
               "hash": "sha256:4b3995b1b0b414f29748e43e3ba90d603d760acef84c71a65b1f05c9b31642d8",
               "eventId": "36592d606de12de2ace7b9456b811097438f51f6df813e071622aa9d85687e10"
+            },
+            "mipsel_24kc-compressed": {
+              "url": "https://blossom.swissdash.site/d26b3c037473360ce5f5a88ca3af53e8ecfaa89c72d05044c0d661b548c090e6.ipk",
+              "hash": "sha256:d26b3c037473360ce5f5a88ca3af53e8ecfaa89c72d05044c0d661b548c090e6",
+              "eventId": "a1f251dd884711ae01f7b7492069a16483fa2ab21bb94cd439af455f9f5d914f"
+            },
+            "aarch64_cortex-a53-compressed": {
+              "url": "https://blossom.swissdash.site/f94b911c2c6b9d19c20a1d0f0e4f232f512ff8c5567f8aa585075f216326190f.ipk",
+              "hash": "sha256:f94b911c2c6b9d19c20a1d0f0e4f232f512ff8c5567f8aa585075f216326190f",
+              "eventId": "b784268acb21c83e103b329c5d9333a61851ce510893e38de8d1e135e20ce7b2"
+            },
+            "mips_24kc-compressed": {
+              "url": "https://blossom.swissdash.site/b73cebd66b510f62fbeb9202f349840a5e72c58d623162e98304ea894a3ab42a.ipk",
+              "hash": "sha256:b73cebd66b510f62fbeb9202f349840a5e72c58d623162e98304ea894a3ab42a",
+              "eventId": "3f0c1c9b578a14859983e0826df64415a07e9fe4e1301c125c714d0a2e0261c3"
+            },
+            "aarch64_cortex-a72-compressed": {
+              "url": "https://blossom.swissdash.site/ef7ec466ac5c6becbb7e39daaeac97d821ea8ab6c141da586f9bb146da9226fc.ipk",
+              "hash": "sha256:ef7ec466ac5c6becbb7e39daaeac97d821ea8ab6c141da586f9bb146da9226fc",
+              "eventId": "a634dd90b6c6f3d1d7082c0c9b2b4a5a2801c9a9c6954870c0674ba225f9410a"
+            },
+            "arm_cortex-a7-compressed": {
+              "url": "https://blossom.swissdash.site/5ec8b21e2a6e37c1bb5ecf8979b5f49a403dc9fc164159a5b68b6d929009e3dd.ipk",
+              "hash": "sha256:5ec8b21e2a6e37c1bb5ecf8979b5f49a403dc9fc164159a5b68b6d929009e3dd",
+              "eventId": "b0b47324862057b29417a2c27bb17de58bbd874be8ca72fe74613523c5a46bcf"
             }
           },
           "dependencies": []

--- a/files/etc/tollgate/release.json
+++ b/files/etc/tollgate/release.json
@@ -9,24 +9,24 @@
           "version": "0.0.1",
           "architectures": {
             "aarch64_cortex-a53": {
-              "url": "https://blossom.swissdash.site/d8ffa8393fe38fc0d72a95feb565a9abbb3ad73f0dc6903f333556daf8bbe8db.ipk",
-              "hash": "sha256:d8ffa8393fe38fc0d72a95feb565a9abbb3ad73f0dc6903f333556daf8bbe8db",
-              "eventId": "d260943d6d1d909a5b3dcc5aeb8616626e05084ee421f9cb1a7e71c06651e966"
+              "url": "https://blossom.swissdash.site/da31fd9472928f635df5dfcddfa51068c31a4a37549392bb80cf3663b2171273.ipk",
+              "hash": "sha256:da31fd9472928f635df5dfcddfa51068c31a4a37549392bb80cf3663b2171273",
+              "eventId": "025b5ecbc1c812165ec1d3d777c48d7a76ec68812ff667b949cb376fe5469223"
             },
             "mipsel_24kc": {
-              "url": "https://blossom.swissdash.site/1b0cf7f249f88566fdbd1899419b60729c1b5cfd322ddda8cd9e6c225a370ddb.ipk",
-              "hash": "sha256:1b0cf7f249f88566fdbd1899419b60729c1b5cfd322ddda8cd9e6c225a370ddb",
-              "eventId": "dbb6b716acc02679e112228aba1a3701412224d624fe908c68e535167d6b3610"
+              "url": "https://blossom.swissdash.site/63870bb329e228ff4de0fa398faf69886ac79539c52edb8441ee9ed60ec9982c.ipk",
+              "hash": "sha256:63870bb329e228ff4de0fa398faf69886ac79539c52edb8441ee9ed60ec9982c",
+              "eventId": "c3480075e53caf4573c41c9daef0319749372321038fe0189bf5ccc4618f9444"
             },
             "mips_24kc": {
-              "url": "https://blossom.swissdash.site/47d730af6008d497d3339b192dd7cd4639d8f711e0d6205f9be830b78b23f95b.ipk",
-              "hash": "sha256:47d730af6008d497d3339b192dd7cd4639d8f711e0d6205f9be830b78b23f95b",
-              "eventId": "65d63c0dd03abff0d9774a005fa1c12dca37b1cec9a615c5e555107ccc8cbdea"
+              "url": "https://blossom.swissdash.site/9cc05b5d36469d74d878a638c86cc5cd3177bc8525f613f087a33a68dbee6883.ipk",
+              "hash": "sha256:9cc05b5d36469d74d878a638c86cc5cd3177bc8525f613f087a33a68dbee6883",
+              "eventId": "79253a6f4cc58ac400db8a809cba3b7a31bd367d5e06bdac404ba67eae37f443"
             },
             "arm_cortex-a7": {
-              "url": "https://blossom.swissdash.site/53bd56dafed6f680ef027780d69867d5514078516cb6104a8fd76e401b34c555.ipk",
-              "hash": "sha256:53bd56dafed6f680ef027780d69867d5514078516cb6104a8fd76e401b34c555",
-              "eventId": "26378565e1b32a412503f4356a8dafc63b042ef5be5e56af1afb577afaa070fa"
+              "url": "https://blossom.swissdash.site/6c2ac0e9a6a397cb3f7f93a046a46ef4fcb5af6b5372a5b9b0d5dabc7fc9a2df.ipk",
+              "hash": "sha256:6c2ac0e9a6a397cb3f7f93a046a46ef4fcb5af6b5372a5b9b0d5dabc7fc9a2df",
+              "eventId": "45a4cbd05f277f25934bb591767f8f6b0dfc06331c9ce5da1337a90f478c432b"
             },
             "arm64_cortex-a53": {
               "url": "https://blossom.swissdash.site/73f0ade7daf36405e580cb7ceb8bbd93f8b35b4b74209bdd5b70eea23ffeb962.ipk",
@@ -34,9 +34,9 @@
               "eventId": "95726da9aed6fa93d2ba72ecb77de95b4b1910cade1b6c2dcd854ff5c56bd7c6"
             },
             "aarch64_cortex-a72": {
-              "url": "https://blossom.swissdash.site/010f0d7c1e626c7f74e004d0d35510733089028daf65ccdcc1160dfccdf774d8.ipk",
-              "hash": "sha256:010f0d7c1e626c7f74e004d0d35510733089028daf65ccdcc1160dfccdf774d8",
-              "eventId": "c61f6a93f6dbde63c6771a1fa431b5789cda5a2e4b7b01c93ecd389394eba6cb"
+              "url": "https://blossom.swissdash.site/3348ffdc1d2780f6f3ed1b6f6eeab7a658c5757d8c93c3b22204148e22959f82.ipk",
+              "hash": "sha256:3348ffdc1d2780f6f3ed1b6f6eeab7a658c5757d8c93c3b22204148e22959f82",
+              "eventId": "6a33c7ec3ea09de7dca15e8a1e1a7c7283d6a3e35325d239ea22d5d88a78eba4"
             },
             "x86_64": {
               "url": "https://blossom.swissdash.site/993aaea07198664c4da5f8dc3437514a015a6c5e488ecf43227ba0d9af5613fe.ipk",

--- a/files/etc/tollgate/release.json
+++ b/files/etc/tollgate/release.json
@@ -9,24 +9,24 @@
           "version": "0.0.1",
           "architectures": {
             "aarch64_cortex-a53": {
-              "url": "https://blossom.swissdash.site/01749491ea7b6c2eaf5e36db4e76c3a86c38bdba35dcfad509d06f8d0ecadd02.ipk",
-              "hash": "sha256:01749491ea7b6c2eaf5e36db4e76c3a86c38bdba35dcfad509d06f8d0ecadd02",
-              "eventId": "78bfab06e5f356e4c69e57f7c6425f9c0bbe55bd50d18502de58897f0054713d"
+              "url": "https://blossom.swissdash.site/cee4f586e7a6d2671f9f3396ad929ac22cca0f03dcd1bc4b5c45c616528e68c6.ipk",
+              "hash": "sha256:cee4f586e7a6d2671f9f3396ad929ac22cca0f03dcd1bc4b5c45c616528e68c6",
+              "eventId": "1c377044f6010f9b2b45f92711efffc9219f1820b1c766556cba675c289ecc7a"
             },
             "mipsel_24kc": {
-              "url": "https://blossom.swissdash.site/afd9da23ab2ae267803d2f7839a57432ecb1d60e678e13431ebea66d2291e630.ipk",
-              "hash": "sha256:afd9da23ab2ae267803d2f7839a57432ecb1d60e678e13431ebea66d2291e630",
-              "eventId": "1af05e2c373ce2ca55556fc90912df20ce598d44ab74f353f697766c6e2c4c75"
+              "url": "https://blossom.swissdash.site/854cc2b606d6a723e0e60d9211ce7c76e59b489448bff449d88c074111765e97.ipk",
+              "hash": "sha256:854cc2b606d6a723e0e60d9211ce7c76e59b489448bff449d88c074111765e97",
+              "eventId": "80c665bd62f0cb3a74c0a5df437ee12c7b301a1133ee8c124cbcc6a0d0ed4813"
             },
             "mips_24kc": {
-              "url": "https://blossom.swissdash.site/2803919152bb8a736de70e8b22cbe495051e9b73e399b039fb59ab05a27cc10b.ipk",
-              "hash": "sha256:2803919152bb8a736de70e8b22cbe495051e9b73e399b039fb59ab05a27cc10b",
-              "eventId": "c58485273adbe36dd7fd0436e452512743c21ef194ddf0a999642ddf3f0c40b2"
+              "url": "https://blossom.swissdash.site/54e7b7ad064e6607e798f6a2b5925b202df91fc7247c33f6f1db4efcb6df04e8.ipk",
+              "hash": "sha256:54e7b7ad064e6607e798f6a2b5925b202df91fc7247c33f6f1db4efcb6df04e8",
+              "eventId": "7ed0d349ac9be5daab1b82ae258c69a4bf1636b7118a4725e3039915f5e402a4"
             },
             "arm_cortex-a7": {
-              "url": "https://blossom.swissdash.site/212ae5f8f336e2eacda6cbf18881427ad9496746b01d5b74b951aafd99119361.ipk",
-              "hash": "sha256:212ae5f8f336e2eacda6cbf18881427ad9496746b01d5b74b951aafd99119361",
-              "eventId": "1038e1bc8f1d0e1912b2b4f7aad04e3c93537e9811318b21f01e664b2d0be3fd"
+              "url": "https://blossom.swissdash.site/20cad22d9056141969a40b0bb25532e55079c372bd8d23bc14385b1a271c2692.ipk",
+              "hash": "sha256:20cad22d9056141969a40b0bb25532e55079c372bd8d23bc14385b1a271c2692",
+              "eventId": "7f72bfc1d2181abc90d6a81b29ac38cffc655052489c4d8c92e4c1f262ab8723"
             },
             "arm64_cortex-a53": {
               "url": "https://blossom.swissdash.site/73f0ade7daf36405e580cb7ceb8bbd93f8b35b4b74209bdd5b70eea23ffeb962.ipk",
@@ -34,9 +34,9 @@
               "eventId": "95726da9aed6fa93d2ba72ecb77de95b4b1910cade1b6c2dcd854ff5c56bd7c6"
             },
             "aarch64_cortex-a72": {
-              "url": "https://blossom.swissdash.site/beb8adeb4976625170aad3f3145a42379e46980636cf3ead16c94abd0bf300f1.ipk",
-              "hash": "sha256:beb8adeb4976625170aad3f3145a42379e46980636cf3ead16c94abd0bf300f1",
-              "eventId": "b34ddfda5464e277cd1c5ad95c236cdfcb459a70205df146b77fa6c8ced41943"
+              "url": "https://blossom.swissdash.site/215b509dd5bfa947289a7e13e006e23c6524c365b8bdb83d7c71481a46f5136b.ipk",
+              "hash": "sha256:215b509dd5bfa947289a7e13e006e23c6524c365b8bdb83d7c71481a46f5136b",
+              "eventId": "1c4505255af597dcf8ed59811b096ee4c135bf51686f16c274205419cec5f3a4"
             }
           },
           "dependencies": []

--- a/files/etc/tollgate/release.json
+++ b/files/etc/tollgate/release.json
@@ -9,24 +9,24 @@
           "version": "0.0.1",
           "architectures": {
             "aarch64_cortex-a53": {
-              "url": "https://blossom.swissdash.site/050227a82c165f9c57899956c6c15392803d75ad73f30fd6a4aa645fee01a61e.ipk",
-              "hash": "sha256:050227a82c165f9c57899956c6c15392803d75ad73f30fd6a4aa645fee01a61e",
-              "eventId": "96e70043f4bcedb95eb6882cb6b00baadd20d73cf8b347b297faf1afc1aaa7b0"
+              "url": "https://blossom.swissdash.site/405690e01d31d579a05f33bffe7222335e402ab8f21fe9b13ec1b75cca3d77e7.ipk",
+              "hash": "sha256:405690e01d31d579a05f33bffe7222335e402ab8f21fe9b13ec1b75cca3d77e7",
+              "eventId": "94570ce33f8761364d6a6e20d9681238f644293f6aed155e66d1cebf7b3bd66f"
             },
             "mipsel_24kc": {
-              "url": "https://blossom.swissdash.site/1edb10f260c1aae07b413bdd0298c320bd697e118a020fb42228a0b3f9d04d46.ipk",
-              "hash": "sha256:1edb10f260c1aae07b413bdd0298c320bd697e118a020fb42228a0b3f9d04d46",
-              "eventId": "69be04efea83f218cefa7f928cd0c8aea4ffc1e44d174d06e21293e6199713f7"
+              "url": "https://blossom.swissdash.site/546b3fbb3f481184b366e3e1315eaba182af2033a13eedbea4c2223c1986a1bc.ipk",
+              "hash": "sha256:546b3fbb3f481184b366e3e1315eaba182af2033a13eedbea4c2223c1986a1bc",
+              "eventId": "fed09af856d08fb8e4005683db2624b90e509af13e5a93c9dc139a99670ed55e"
             },
             "mips_24kc": {
-              "url": "https://blossom.swissdash.site/649cb2b378036a0cedd293211e9dd32a18cbe52e4440a47f35d815101f5fb1ab.ipk",
-              "hash": "sha256:649cb2b378036a0cedd293211e9dd32a18cbe52e4440a47f35d815101f5fb1ab",
-              "eventId": "7cfa17865b55aebfac698ad9c80ef1e6b294130b488aac77e9d10aed7ce55d5f"
+              "url": "https://blossom.swissdash.site/91be25ac2688b5747acbeb0ef29604034ff16751a65df265164a778db04d5d1b.ipk",
+              "hash": "sha256:91be25ac2688b5747acbeb0ef29604034ff16751a65df265164a778db04d5d1b",
+              "eventId": "c14db016042c4635b8e5b9d198c6d791345363599e23762280838e792dd71243"
             },
             "arm_cortex-a7": {
-              "url": "https://blossom.swissdash.site/a869c76660b5141de60f0945812618ee7f6cedcd0eb27e8d4136e294bace2347.ipk",
-              "hash": "sha256:a869c76660b5141de60f0945812618ee7f6cedcd0eb27e8d4136e294bace2347",
-              "eventId": "45f60de619a67223bb92a35855b380d6ff6c5cb6ebf784d0b7948ba47f78ce9a"
+              "url": "https://blossom.swissdash.site/1f08a3708919e8fd81b8cefe32796c36a85aeb5cc4c9f5adb8250a651839b255.ipk",
+              "hash": "sha256:1f08a3708919e8fd81b8cefe32796c36a85aeb5cc4c9f5adb8250a651839b255",
+              "eventId": "e751d3d035328290604a76a289efa22ca6c4d48a5e1835846b6ec8568f155384"
             },
             "arm64_cortex-a53": {
               "url": "https://blossom.swissdash.site/73f0ade7daf36405e580cb7ceb8bbd93f8b35b4b74209bdd5b70eea23ffeb962.ipk",
@@ -34,9 +34,9 @@
               "eventId": "95726da9aed6fa93d2ba72ecb77de95b4b1910cade1b6c2dcd854ff5c56bd7c6"
             },
             "aarch64_cortex-a72": {
-              "url": "https://blossom.swissdash.site/afd0bdf0ed4503842290d408af5469521f72f2846663566b701ff7163232ab69.ipk",
-              "hash": "sha256:afd0bdf0ed4503842290d408af5469521f72f2846663566b701ff7163232ab69",
-              "eventId": "e2ad1ba073f0193367b3c5470b24253ccc2cdef2cda1b6e36f883df950dacdd4"
+              "url": "https://blossom.swissdash.site/e63645dbeed97a08fd9ada5168be372def029bb03d4da4742ab9fc7fb77a09f1.ipk",
+              "hash": "sha256:e63645dbeed97a08fd9ada5168be372def029bb03d4da4742ab9fc7fb77a09f1",
+              "eventId": "5f89638aaf7d78ebfb02a29e71fc8ab8dcf154dae83428eba2c448415b7a0321"
             }
           },
           "dependencies": []

--- a/files/etc/tollgate/release.json
+++ b/files/etc/tollgate/release.json
@@ -9,24 +9,24 @@
           "version": "0.0.1",
           "architectures": {
             "aarch64_cortex-a53": {
-              "url": "https://blossom.swissdash.site/6e43ff301370316dc2abb79d0879ab036a4c54ea048d23727207b4f264d2839f.ipk",
-              "hash": "sha256:6e43ff301370316dc2abb79d0879ab036a4c54ea048d23727207b4f264d2839f",
-              "eventId": "a52941831a59cbc614c603acbc6f3b0c53eaf5bc521a3cd0687c277c0de21f55"
+              "url": "https://blossom.swissdash.site/8097ec484c5927b365a45c99d465f779dbb5f62175ead25db47df6c6593b1101.ipk",
+              "hash": "sha256:8097ec484c5927b365a45c99d465f779dbb5f62175ead25db47df6c6593b1101",
+              "eventId": "dc79a88af8292adb311b2a3d01493c67cb9cb214f222631fd544ffc15536fab7"
             },
             "mipsel_24kc": {
-              "url": "https://blossom.swissdash.site/595639c9ef284d51e26bc5a6e8eee7eb91aab9836edd1f60f1f38f19d103255a.ipk",
-              "hash": "sha256:595639c9ef284d51e26bc5a6e8eee7eb91aab9836edd1f60f1f38f19d103255a",
-              "eventId": "ac34c39c4c8fc45c9994b554880c458ba76f386dee92142253ceed2823adcb0f"
+              "url": "https://blossom.swissdash.site/ced95d7af612f846c97864a310d5891de326db2ed9fc220a7d9e167e74b71d66.ipk",
+              "hash": "sha256:ced95d7af612f846c97864a310d5891de326db2ed9fc220a7d9e167e74b71d66",
+              "eventId": "f0a8ee83935fc9dec5ca9e61f5ca6471abcb47444158d962c9811bcd1c27e102"
             },
             "mips_24kc": {
-              "url": "https://blossom.swissdash.site/49f3b7167273844a91d5c451b85a13d98efc7180d9fc0b4824a40d7de861f3d0.ipk",
-              "hash": "sha256:49f3b7167273844a91d5c451b85a13d98efc7180d9fc0b4824a40d7de861f3d0",
-              "eventId": "980dbd63b57e37ba2bbfdfdabf285a45bb3cc66058f3acfd05cb3188e03352dd"
+              "url": "https://blossom.swissdash.site/f748f1e772d40cd8c87a057a798abaf1b218b0f0eb20801e3c1652a17c90695d.ipk",
+              "hash": "sha256:f748f1e772d40cd8c87a057a798abaf1b218b0f0eb20801e3c1652a17c90695d",
+              "eventId": "7aeec15d9fc74099549a49dd6a606b60f12fde6576e291753f0fe46b801d2054"
             },
             "arm_cortex-a7": {
-              "url": "https://blossom.swissdash.site/53168c2378fb7723b8b82abd4679b1a8a424c133ff6087de0bf353c934d08c29.ipk",
-              "hash": "sha256:53168c2378fb7723b8b82abd4679b1a8a424c133ff6087de0bf353c934d08c29",
-              "eventId": "a937947239000ca103fcfe47c14f67127793c3708376b8d8b2f1579b3420acaa"
+              "url": "https://blossom.swissdash.site/5f9b2959f358163d13ede1706968620257fc71f85d59e3577b50b559de683dc1.ipk",
+              "hash": "sha256:5f9b2959f358163d13ede1706968620257fc71f85d59e3577b50b559de683dc1",
+              "eventId": "61b37fe5a1a25311a89b6d6b04942bb7f089d87755323f28e037fb05255a0e8f"
             },
             "arm64_cortex-a53": {
               "url": "https://blossom.swissdash.site/73f0ade7daf36405e580cb7ceb8bbd93f8b35b4b74209bdd5b70eea23ffeb962.ipk",
@@ -34,9 +34,9 @@
               "eventId": "95726da9aed6fa93d2ba72ecb77de95b4b1910cade1b6c2dcd854ff5c56bd7c6"
             },
             "aarch64_cortex-a72": {
-              "url": "https://blossom.swissdash.site/39aed3a2c3e443571e32a895e2f86460ca436bc6eeddbbf5eaae4bf9592d6788.ipk",
-              "hash": "sha256:39aed3a2c3e443571e32a895e2f86460ca436bc6eeddbbf5eaae4bf9592d6788",
-              "eventId": "7e83eff04da76859637333945722f89a9af1f140f4c0b8cd29c7b9af3410d1ec"
+              "url": "https://blossom.swissdash.site/e69b22bebe0fa0cfd04aa60178ad681aa58cf889a4e6c31c0a3b300881963180.ipk",
+              "hash": "sha256:e69b22bebe0fa0cfd04aa60178ad681aa58cf889a4e6c31c0a3b300881963180",
+              "eventId": "8f5d57637b047bcce2e904e5a43c1d9eac6963cac203e6a59d1c652532beffbf"
             },
             "x86_64": {
               "url": "https://blossom.swissdash.site/993aaea07198664c4da5f8dc3437514a015a6c5e488ecf43227ba0d9af5613fe.ipk",
@@ -74,29 +74,29 @@
               "eventId": "36592d606de12de2ace7b9456b811097438f51f6df813e071622aa9d85687e10"
             },
             "mipsel_24kc-compressed": {
-              "url": "https://blossom.swissdash.site/d26b3c037473360ce5f5a88ca3af53e8ecfaa89c72d05044c0d661b548c090e6.ipk",
-              "hash": "sha256:d26b3c037473360ce5f5a88ca3af53e8ecfaa89c72d05044c0d661b548c090e6",
-              "eventId": "a1f251dd884711ae01f7b7492069a16483fa2ab21bb94cd439af455f9f5d914f"
+              "url": "https://blossom.swissdash.site/e0700cb4483ff9ac22f886c544a114895b29df3d344af70c8f0056ff9f5aa7ea.ipk",
+              "hash": "sha256:e0700cb4483ff9ac22f886c544a114895b29df3d344af70c8f0056ff9f5aa7ea",
+              "eventId": "d3edbd940e6d56788fe56729f91a41e0c2b2c83046b08b1d128c8f8604a005bc"
             },
             "aarch64_cortex-a53-compressed": {
-              "url": "https://blossom.swissdash.site/f94b911c2c6b9d19c20a1d0f0e4f232f512ff8c5567f8aa585075f216326190f.ipk",
-              "hash": "sha256:f94b911c2c6b9d19c20a1d0f0e4f232f512ff8c5567f8aa585075f216326190f",
-              "eventId": "b784268acb21c83e103b329c5d9333a61851ce510893e38de8d1e135e20ce7b2"
+              "url": "https://blossom.swissdash.site/9e251bf5d114f66dca638f6149ca1ec4bf97f7688bb4d40b612f69a0483ef30f.ipk",
+              "hash": "sha256:9e251bf5d114f66dca638f6149ca1ec4bf97f7688bb4d40b612f69a0483ef30f",
+              "eventId": "67d34692ad61b2c5304aeb701f2646d15295b6223b820f04b18961eeaf4b5182"
             },
             "mips_24kc-compressed": {
-              "url": "https://blossom.swissdash.site/b73cebd66b510f62fbeb9202f349840a5e72c58d623162e98304ea894a3ab42a.ipk",
-              "hash": "sha256:b73cebd66b510f62fbeb9202f349840a5e72c58d623162e98304ea894a3ab42a",
-              "eventId": "3f0c1c9b578a14859983e0826df64415a07e9fe4e1301c125c714d0a2e0261c3"
+              "url": "https://blossom.swissdash.site/a2046f7e13a02add3e47296ace6c04f7526ec37edfd3239b5c468bbd01a2cb76.ipk",
+              "hash": "sha256:a2046f7e13a02add3e47296ace6c04f7526ec37edfd3239b5c468bbd01a2cb76",
+              "eventId": "325697c5bf7a85586e88ce9fe0a3d6f4a625ec4659026a21723f6ea6e8a50ba1"
             },
             "aarch64_cortex-a72-compressed": {
-              "url": "https://blossom.swissdash.site/ef7ec466ac5c6becbb7e39daaeac97d821ea8ab6c141da586f9bb146da9226fc.ipk",
-              "hash": "sha256:ef7ec466ac5c6becbb7e39daaeac97d821ea8ab6c141da586f9bb146da9226fc",
-              "eventId": "a634dd90b6c6f3d1d7082c0c9b2b4a5a2801c9a9c6954870c0674ba225f9410a"
+              "url": "https://blossom.swissdash.site/6e496ae0e64813ca3329cc445cdadc692dc6fda6c1682d8f69e30a5733b52138.ipk",
+              "hash": "sha256:6e496ae0e64813ca3329cc445cdadc692dc6fda6c1682d8f69e30a5733b52138",
+              "eventId": "17be772e3b5f034c9f3ae78753a40ac9f0c679b2623436e3cc6897a12917d641"
             },
             "arm_cortex-a7-compressed": {
-              "url": "https://blossom.swissdash.site/5ec8b21e2a6e37c1bb5ecf8979b5f49a403dc9fc164159a5b68b6d929009e3dd.ipk",
-              "hash": "sha256:5ec8b21e2a6e37c1bb5ecf8979b5f49a403dc9fc164159a5b68b6d929009e3dd",
-              "eventId": "b0b47324862057b29417a2c27bb17de58bbd874be8ca72fe74613523c5a46bcf"
+              "url": "https://blossom.swissdash.site/0c897c396029a24daaf82b6bb50e307fb4c97629badf0cab4e44266bbf4bb3b9.ipk",
+              "hash": "sha256:0c897c396029a24daaf82b6bb50e307fb4c97629badf0cab4e44266bbf4bb3b9",
+              "eventId": "742e6ca9a3b010e7eed941f3d4e183f0fbba8b3b8e990f97b52a7aaba98f0eae"
             }
           },
           "dependencies": []

--- a/files/etc/tollgate/release.json
+++ b/files/etc/tollgate/release.json
@@ -9,24 +9,24 @@
           "version": "0.0.1",
           "architectures": {
             "aarch64_cortex-a53": {
-              "url": "https://blossom.swissdash.site/cee4f586e7a6d2671f9f3396ad929ac22cca0f03dcd1bc4b5c45c616528e68c6.ipk",
-              "hash": "sha256:cee4f586e7a6d2671f9f3396ad929ac22cca0f03dcd1bc4b5c45c616528e68c6",
-              "eventId": "1c377044f6010f9b2b45f92711efffc9219f1820b1c766556cba675c289ecc7a"
+              "url": "https://blossom.swissdash.site/844a1bae05b0df81ab212799f51947e6c578546a446aa7555cc8bf1a23f5928e.ipk",
+              "hash": "sha256:844a1bae05b0df81ab212799f51947e6c578546a446aa7555cc8bf1a23f5928e",
+              "eventId": "d61a3c319653263e69e68bd103f6cb83650a9f48f8b92faedd4e9f6e306685dd"
             },
             "mipsel_24kc": {
-              "url": "https://blossom.swissdash.site/854cc2b606d6a723e0e60d9211ce7c76e59b489448bff449d88c074111765e97.ipk",
-              "hash": "sha256:854cc2b606d6a723e0e60d9211ce7c76e59b489448bff449d88c074111765e97",
-              "eventId": "80c665bd62f0cb3a74c0a5df437ee12c7b301a1133ee8c124cbcc6a0d0ed4813"
+              "url": "https://blossom.swissdash.site/def9bb8442eb2136839f787c319a73645cdc9b9599defef975987277d6a1c720.ipk",
+              "hash": "sha256:def9bb8442eb2136839f787c319a73645cdc9b9599defef975987277d6a1c720",
+              "eventId": "f90ad812c20996d02b14269ee766a049d00cbd37a31268bc10a2462c75fea7aa"
             },
             "mips_24kc": {
-              "url": "https://blossom.swissdash.site/54e7b7ad064e6607e798f6a2b5925b202df91fc7247c33f6f1db4efcb6df04e8.ipk",
-              "hash": "sha256:54e7b7ad064e6607e798f6a2b5925b202df91fc7247c33f6f1db4efcb6df04e8",
-              "eventId": "7ed0d349ac9be5daab1b82ae258c69a4bf1636b7118a4725e3039915f5e402a4"
+              "url": "https://blossom.swissdash.site/552703627f99ff4ef6ae3169cb09dbc72eb7bcd067edc15cec534ffaf8e4ac2e.ipk",
+              "hash": "sha256:552703627f99ff4ef6ae3169cb09dbc72eb7bcd067edc15cec534ffaf8e4ac2e",
+              "eventId": "e9b8ee1e8a3c30afd544f7541f6c946238b3b33b9c016c9fa024fa21460b62ae"
             },
             "arm_cortex-a7": {
-              "url": "https://blossom.swissdash.site/20cad22d9056141969a40b0bb25532e55079c372bd8d23bc14385b1a271c2692.ipk",
-              "hash": "sha256:20cad22d9056141969a40b0bb25532e55079c372bd8d23bc14385b1a271c2692",
-              "eventId": "7f72bfc1d2181abc90d6a81b29ac38cffc655052489c4d8c92e4c1f262ab8723"
+              "url": "https://blossom.swissdash.site/39a3f511e6a37a2b45793909411db1ec5bfeba2aaa9f3891e2688338f2735257.ipk",
+              "hash": "sha256:39a3f511e6a37a2b45793909411db1ec5bfeba2aaa9f3891e2688338f2735257",
+              "eventId": "c1ee5dbd4e72a9573f5885ac88d5fa5148416ae1b5d48134bcf0a3a240bde910"
             },
             "arm64_cortex-a53": {
               "url": "https://blossom.swissdash.site/73f0ade7daf36405e580cb7ceb8bbd93f8b35b4b74209bdd5b70eea23ffeb962.ipk",
@@ -34,9 +34,9 @@
               "eventId": "95726da9aed6fa93d2ba72ecb77de95b4b1910cade1b6c2dcd854ff5c56bd7c6"
             },
             "aarch64_cortex-a72": {
-              "url": "https://blossom.swissdash.site/215b509dd5bfa947289a7e13e006e23c6524c365b8bdb83d7c71481a46f5136b.ipk",
-              "hash": "sha256:215b509dd5bfa947289a7e13e006e23c6524c365b8bdb83d7c71481a46f5136b",
-              "eventId": "1c4505255af597dcf8ed59811b096ee4c135bf51686f16c274205419cec5f3a4"
+              "url": "https://blossom.swissdash.site/13aa21af019aa143de530882bc033081108cd03b814a7d727207389e3ecb0f10.ipk",
+              "hash": "sha256:13aa21af019aa143de530882bc033081108cd03b814a7d727207389e3ecb0f10",
+              "eventId": "7bd4410a7d302a7e546576e4473ccb5a3ae73ecae1280d9f1d02885604b71754"
             }
           },
           "dependencies": []

--- a/files/etc/tollgate/release.json
+++ b/files/etc/tollgate/release.json
@@ -9,24 +9,24 @@
           "version": "0.0.1",
           "architectures": {
             "aarch64_cortex-a53": {
-              "url": "https://blossom.swissdash.site/f3ed93ffbf992487d9233e7368f9e2c3271145c19e5d1c10c0a9f46a2c1d0838.ipk",
-              "hash": "sha256:f3ed93ffbf992487d9233e7368f9e2c3271145c19e5d1c10c0a9f46a2c1d0838",
-              "eventId": "1ebc7c227236baaada06c6976f5d2f412802261fbae6c87abcaab0832e13518e"
+              "url": "https://blossom.swissdash.site/a1b55ed2f4c821ec5057376fe6dda2c84a3e7786bac72aac08c2b51e28262c61.ipk",
+              "hash": "sha256:a1b55ed2f4c821ec5057376fe6dda2c84a3e7786bac72aac08c2b51e28262c61",
+              "eventId": "8cb4f150927b748ae69e1eb5b9d1113a3b6438b4eda570b69177017108952606"
             },
             "mipsel_24kc": {
-              "url": "https://blossom.swissdash.site/8f9f1a9cee95927227e45359722f43666b02297b134d52423fc3ddc6e266ab36.ipk",
-              "hash": "sha256:8f9f1a9cee95927227e45359722f43666b02297b134d52423fc3ddc6e266ab36",
-              "eventId": "4bc6c645b1679482b49fd70b6792c8b306962e3ee4a36eb5259c4edf08766350"
+              "url": "https://blossom.swissdash.site/669c697ce733097bb5d586fee95a5d4c7cf91830670e1a21bae1670834fb240a.ipk",
+              "hash": "sha256:669c697ce733097bb5d586fee95a5d4c7cf91830670e1a21bae1670834fb240a",
+              "eventId": "2e64b2af13682145cf0dad1aa3c1df084399b155d818ab291dc3cedd5ddd81a5"
             },
             "mips_24kc": {
-              "url": "https://blossom.swissdash.site/8a34708d6daee9e57f1d5b6c66816c417b57c673e90dd053389c20be352c0ab1.ipk",
-              "hash": "sha256:8a34708d6daee9e57f1d5b6c66816c417b57c673e90dd053389c20be352c0ab1",
-              "eventId": "56bc8948707b795d448e6e5da4c8dd9411dc67e3ed3dd6fd94a0c561e0481d11"
+              "url": "https://blossom.swissdash.site/047662c9112ff33e59d41adc1d00e467bc5319f9487d3173e2f8e3384acb6089.ipk",
+              "hash": "sha256:047662c9112ff33e59d41adc1d00e467bc5319f9487d3173e2f8e3384acb6089",
+              "eventId": "835eb40cb2051e0d28e9a4ba25012349241afb07d81385647dd6a5057c6012a4"
             },
             "arm_cortex-a7": {
-              "url": "https://blossom.swissdash.site/5d354cd330cccae80f063761353557bff406a611c86b873ad8a46be7e1fe4069.ipk",
-              "hash": "sha256:5d354cd330cccae80f063761353557bff406a611c86b873ad8a46be7e1fe4069",
-              "eventId": "bd93fac16ef2427dbfd91cc6c8ff858013fc4eb590764b8339c464f92f946322"
+              "url": "https://blossom.swissdash.site/bfdb2ea1fc863535c54e7067b943f48097ee76bb0a332dc45e502aa884f554a9.ipk",
+              "hash": "sha256:bfdb2ea1fc863535c54e7067b943f48097ee76bb0a332dc45e502aa884f554a9",
+              "eventId": "814a628d3abc1fd1f6308618560db54998ff9836b8aedaae1e7f5f6de3ab54a4"
             },
             "arm64_cortex-a53": {
               "url": "https://blossom.swissdash.site/73f0ade7daf36405e580cb7ceb8bbd93f8b35b4b74209bdd5b70eea23ffeb962.ipk",
@@ -34,9 +34,9 @@
               "eventId": "95726da9aed6fa93d2ba72ecb77de95b4b1910cade1b6c2dcd854ff5c56bd7c6"
             },
             "aarch64_cortex-a72": {
-              "url": "https://blossom.swissdash.site/312eb5e4051968801d4134c1cfe1c99cd36b2711ec87344130bc78d191d30c06.ipk",
-              "hash": "sha256:312eb5e4051968801d4134c1cfe1c99cd36b2711ec87344130bc78d191d30c06",
-              "eventId": "3270e0d178dca767c4ef8952ec2d53557a8fc00dcccfd9f61c0fa218b21cf600"
+              "url": "https://blossom.swissdash.site/cb0b2620bae3acff44dd0b146360d9ff26d575af4d5db8c54258dd666d86d8de.ipk",
+              "hash": "sha256:cb0b2620bae3acff44dd0b146360d9ff26d575af4d5db8c54258dd666d86d8de",
+              "eventId": "4cdb17e070b08184b43968bc3d276da1553e2773f7f43f495925fb261ed62595"
             }
           },
           "dependencies": []

--- a/files/etc/tollgate/release.json
+++ b/files/etc/tollgate/release.json
@@ -9,24 +9,24 @@
           "version": "0.0.1",
           "architectures": {
             "aarch64_cortex-a53": {
-              "url": "https://blossom.swissdash.site/d39be9e533cc58886d80185c3e3d0c19e0cfa25a445e80580220524acc6d98c5.ipk",
-              "hash": "sha256:d39be9e533cc58886d80185c3e3d0c19e0cfa25a445e80580220524acc6d98c5",
-              "eventId": "6e2e25f9e5bf128722d43064dde87ea3f7daa57d59c8c62172ff08808ba0a16a"
+              "url": "https://blossom.swissdash.site/793df2e2199a78a92e69b7c42ba8bad85931e01d10f1d528ad193a637d7438a3.ipk",
+              "hash": "sha256:793df2e2199a78a92e69b7c42ba8bad85931e01d10f1d528ad193a637d7438a3",
+              "eventId": "114696da50146f94072f022abd4d88527f947a03d4116b23f37f436f46eecf9f"
             },
             "mipsel_24kc": {
-              "url": "https://blossom.swissdash.site/18d697b0b570a4ba85687a2ec2c587f364a21c4605bc13f4112784618ede7c7e.ipk",
-              "hash": "sha256:18d697b0b570a4ba85687a2ec2c587f364a21c4605bc13f4112784618ede7c7e",
-              "eventId": "dacf3fe493e3978623486de651d261b758a19b2a6d1c9652bc8cc288efd031d9"
+              "url": "https://blossom.swissdash.site/73b8b6dac0bf3e1c0fe13c5eb1ed85c133e823e17498a5f6abb47ecd8c6e9541.ipk",
+              "hash": "sha256:73b8b6dac0bf3e1c0fe13c5eb1ed85c133e823e17498a5f6abb47ecd8c6e9541",
+              "eventId": "1794f24cde130a88fe55740172740340ddcf4c670610924f342da3726612bfce"
             },
             "mips_24kc": {
-              "url": "https://blossom.swissdash.site/5b4d3c92fc4abf4848f47c6be8914906070f582fe9c67f7d12fc36e8215ae7ca.ipk",
-              "hash": "sha256:5b4d3c92fc4abf4848f47c6be8914906070f582fe9c67f7d12fc36e8215ae7ca",
-              "eventId": "118aa8bcbe9a5a7b71d25db738f58f21ff53ca8f125bdcd80213c52f799f8969"
+              "url": "https://blossom.swissdash.site/249daff55f387bc394d8b0403ac601e85eb907635ddee3c66b4a589744ae60ef.ipk",
+              "hash": "sha256:249daff55f387bc394d8b0403ac601e85eb907635ddee3c66b4a589744ae60ef",
+              "eventId": "40b36d6a5e4d27bbd1c5b064ea1ac226bed15f0d9d8c896e3842e99702bc88a0"
             },
             "arm_cortex-a7": {
-              "url": "https://blossom.swissdash.site/55458bcb26e1fa3dd2ab5cb84ea7a00c7b3a93808d3bacfab85605fdb573d627.ipk",
-              "hash": "sha256:55458bcb26e1fa3dd2ab5cb84ea7a00c7b3a93808d3bacfab85605fdb573d627",
-              "eventId": "402611d13c082268f2d10d1ff97f2801b01757ceb8627cde6a11a48ba8704c7c"
+              "url": "https://blossom.swissdash.site/66e0c8d41a66f89985f13ed1fe146c0b29db5714ef0b517c07c044facaf8b02a.ipk",
+              "hash": "sha256:66e0c8d41a66f89985f13ed1fe146c0b29db5714ef0b517c07c044facaf8b02a",
+              "eventId": "b66e2e58712db6b2692dcb5b9da7f3bb8ec09c453bbc94a9ce8bed31f7fb5c72"
             },
             "arm64_cortex-a53": {
               "url": "https://blossom.swissdash.site/73f0ade7daf36405e580cb7ceb8bbd93f8b35b4b74209bdd5b70eea23ffeb962.ipk",
@@ -34,9 +34,9 @@
               "eventId": "95726da9aed6fa93d2ba72ecb77de95b4b1910cade1b6c2dcd854ff5c56bd7c6"
             },
             "aarch64_cortex-a72": {
-              "url": "https://blossom.swissdash.site/0c34cca8bb5726160b9623f288733c4625a1540dabcba36c7496e26dbeb77b90.ipk",
-              "hash": "sha256:0c34cca8bb5726160b9623f288733c4625a1540dabcba36c7496e26dbeb77b90",
-              "eventId": "f3b6f180a9a577aa548773858b7ddd352c7112b36a5a9c0bd189aff46feb96bd"
+              "url": "https://blossom.swissdash.site/287e740d0964a4a26dcc65b862f228d9fc1d1a8ec6b87afe5507188ff7de697c.ipk",
+              "hash": "sha256:287e740d0964a4a26dcc65b862f228d9fc1d1a8ec6b87afe5507188ff7de697c",
+              "eventId": "fb394912f883b5f6f9b63ec0f8b569ca1613169255fce473140e91c703e04f1b"
             }
           },
           "dependencies": []

--- a/files/etc/tollgate/release.json
+++ b/files/etc/tollgate/release.json
@@ -9,24 +9,24 @@
           "version": "0.0.1",
           "architectures": {
             "aarch64_cortex-a53": {
-              "url": "https://blossom.swissdash.site/8097ec484c5927b365a45c99d465f779dbb5f62175ead25db47df6c6593b1101.ipk",
-              "hash": "sha256:8097ec484c5927b365a45c99d465f779dbb5f62175ead25db47df6c6593b1101",
-              "eventId": "dc79a88af8292adb311b2a3d01493c67cb9cb214f222631fd544ffc15536fab7"
+              "url": "https://blossom.swissdash.site/18d138784715f6a375413525bf82a4f9bf4957f5140749487a7b331060564935.ipk",
+              "hash": "sha256:18d138784715f6a375413525bf82a4f9bf4957f5140749487a7b331060564935",
+              "eventId": "4d57e11dbe3486aaa740249273ebba4e527025e28c7ea75767678fcad95fc137"
             },
             "mipsel_24kc": {
-              "url": "https://blossom.swissdash.site/ced95d7af612f846c97864a310d5891de326db2ed9fc220a7d9e167e74b71d66.ipk",
-              "hash": "sha256:ced95d7af612f846c97864a310d5891de326db2ed9fc220a7d9e167e74b71d66",
-              "eventId": "f0a8ee83935fc9dec5ca9e61f5ca6471abcb47444158d962c9811bcd1c27e102"
+              "url": "https://blossom.swissdash.site/fd0cfaa54bcc2d40eac01515c65a542c343153996791721da724efce23f56846.ipk",
+              "hash": "sha256:fd0cfaa54bcc2d40eac01515c65a542c343153996791721da724efce23f56846",
+              "eventId": "807065bd6a0f1f166ced036e499d7bc13398229b6aadd4ceaaa6d78340978bec"
             },
             "mips_24kc": {
-              "url": "https://blossom.swissdash.site/f748f1e772d40cd8c87a057a798abaf1b218b0f0eb20801e3c1652a17c90695d.ipk",
-              "hash": "sha256:f748f1e772d40cd8c87a057a798abaf1b218b0f0eb20801e3c1652a17c90695d",
-              "eventId": "7aeec15d9fc74099549a49dd6a606b60f12fde6576e291753f0fe46b801d2054"
+              "url": "https://blossom.swissdash.site/7b5aed471a548535342ab36663046d7a4dacef3a5c1914372c4e96d0cfa68294.ipk",
+              "hash": "sha256:7b5aed471a548535342ab36663046d7a4dacef3a5c1914372c4e96d0cfa68294",
+              "eventId": "a7b262b0566c7d164db5bb28ce72ac1e5636f16717f006aa5c3f9f23c09a6b5e"
             },
             "arm_cortex-a7": {
-              "url": "https://blossom.swissdash.site/5f9b2959f358163d13ede1706968620257fc71f85d59e3577b50b559de683dc1.ipk",
-              "hash": "sha256:5f9b2959f358163d13ede1706968620257fc71f85d59e3577b50b559de683dc1",
-              "eventId": "61b37fe5a1a25311a89b6d6b04942bb7f089d87755323f28e037fb05255a0e8f"
+              "url": "https://blossom.swissdash.site/d76620694c0d852df66a9c0d5f5f3a3c0386effc07d3415dddb5d15665197a57.ipk",
+              "hash": "sha256:d76620694c0d852df66a9c0d5f5f3a3c0386effc07d3415dddb5d15665197a57",
+              "eventId": "8c27146165e1adaa9e9ef5db77561108e0a5a712d8dffa5199fb6004f6a99559"
             },
             "arm64_cortex-a53": {
               "url": "https://blossom.swissdash.site/73f0ade7daf36405e580cb7ceb8bbd93f8b35b4b74209bdd5b70eea23ffeb962.ipk",
@@ -34,9 +34,9 @@
               "eventId": "95726da9aed6fa93d2ba72ecb77de95b4b1910cade1b6c2dcd854ff5c56bd7c6"
             },
             "aarch64_cortex-a72": {
-              "url": "https://blossom.swissdash.site/e69b22bebe0fa0cfd04aa60178ad681aa58cf889a4e6c31c0a3b300881963180.ipk",
-              "hash": "sha256:e69b22bebe0fa0cfd04aa60178ad681aa58cf889a4e6c31c0a3b300881963180",
-              "eventId": "8f5d57637b047bcce2e904e5a43c1d9eac6963cac203e6a59d1c652532beffbf"
+              "url": "https://blossom.swissdash.site/3ef409c11a038c00700ce6adb080076bd91d6ce9e89887927762cc50ba0005d8.ipk",
+              "hash": "sha256:3ef409c11a038c00700ce6adb080076bd91d6ce9e89887927762cc50ba0005d8",
+              "eventId": "8a90b0f8d80650e3844af9891188df6b85bcdb34ce9af7da4692fa38806b52b4"
             },
             "x86_64": {
               "url": "https://blossom.swissdash.site/993aaea07198664c4da5f8dc3437514a015a6c5e488ecf43227ba0d9af5613fe.ipk",

--- a/files/etc/tollgate/release.json
+++ b/files/etc/tollgate/release.json
@@ -9,24 +9,24 @@
           "version": "0.0.1",
           "architectures": {
             "aarch64_cortex-a53": {
-              "url": "https://blossom.swissdash.site/17bd83ca9284b8ce317a627647dd69db02bd6d83385c08a1b4dc04bdd83e7ecb.ipk",
-              "hash": "sha256:17bd83ca9284b8ce317a627647dd69db02bd6d83385c08a1b4dc04bdd83e7ecb",
-              "eventId": "970d1c8070a277db63676112a0804a89e8f577ec4e80d692204397cddb5eb930"
+              "url": "https://blossom.swissdash.site/a7d9d4e6ccf6085ad560fc4e06960a8e5095675336df81e2c2c21eb99787901c.ipk",
+              "hash": "sha256:a7d9d4e6ccf6085ad560fc4e06960a8e5095675336df81e2c2c21eb99787901c",
+              "eventId": "8e8c4319a1f3db3572b659535ee935d47639866ddf0243d3875776c45ca0301c"
             },
             "mipsel_24kc": {
-              "url": "https://blossom.swissdash.site/9298db0ee5655c29c80d9ea3123df00747b4e53b9dcd472bc901434bc70697bf.ipk",
-              "hash": "sha256:9298db0ee5655c29c80d9ea3123df00747b4e53b9dcd472bc901434bc70697bf",
-              "eventId": "16deb2697f5bb1fd1a66f64c348386ea159e857f8e3deb7683be11acbc66e5ee"
+              "url": "https://blossom.swissdash.site/5c83b61c2ff5e7d00338938188b32a83d6906cecb56ab4d6b3f4804cf6558773.ipk",
+              "hash": "sha256:5c83b61c2ff5e7d00338938188b32a83d6906cecb56ab4d6b3f4804cf6558773",
+              "eventId": "061e5b8ff1a28fe1f56a0d57f4171fb329dc6b12eccbed9031072744877d5a21"
             },
             "mips_24kc": {
-              "url": "https://blossom.swissdash.site/18511620258a7ff3a513da09349164e121468a1e8e69b6cb533289957c8333a4.ipk",
-              "hash": "sha256:18511620258a7ff3a513da09349164e121468a1e8e69b6cb533289957c8333a4",
-              "eventId": "7b71e83644f848102b407b2656eba014790555b304b32e823737fe98611405dd"
+              "url": "https://blossom.swissdash.site/089906e58207eba1aa179f0e43fbcf53fd58c733381127a55e506b67a9eb36f1.ipk",
+              "hash": "sha256:089906e58207eba1aa179f0e43fbcf53fd58c733381127a55e506b67a9eb36f1",
+              "eventId": "02e90489ede461956dd49c0d16279f9c0dd0740293e8ec109dafbced01be41c1"
             },
             "arm_cortex-a7": {
-              "url": "https://blossom.swissdash.site/aa49a21c5b55ac4f41ee9ee2ad731532f108145c416f66f67c17ebe43b41c254.ipk",
-              "hash": "sha256:aa49a21c5b55ac4f41ee9ee2ad731532f108145c416f66f67c17ebe43b41c254",
-              "eventId": "07f7d5dac8af8fe990301b39b67b916c1351d0279737fd8fce374cbb03f13b6f"
+              "url": "https://blossom.swissdash.site/34ea09adde156c2dc8bc57a8da231440b2568898f5cae581bae3f28fd78771a9.ipk",
+              "hash": "sha256:34ea09adde156c2dc8bc57a8da231440b2568898f5cae581bae3f28fd78771a9",
+              "eventId": "83b4273c1b6e6fec16dec09043959574dbfa7682a1166c0bcd9844fd712cc118"
             },
             "arm64_cortex-a53": {
               "url": "https://blossom.swissdash.site/73f0ade7daf36405e580cb7ceb8bbd93f8b35b4b74209bdd5b70eea23ffeb962.ipk",
@@ -34,9 +34,9 @@
               "eventId": "95726da9aed6fa93d2ba72ecb77de95b4b1910cade1b6c2dcd854ff5c56bd7c6"
             },
             "aarch64_cortex-a72": {
-              "url": "https://blossom.swissdash.site/681dd348406f6318ae70cce8e6545f71218abc1f8809d88cd3231c474d8e189f.ipk",
-              "hash": "sha256:681dd348406f6318ae70cce8e6545f71218abc1f8809d88cd3231c474d8e189f",
-              "eventId": "d45a43921531271a2e86ede0c2b3b863b9dad6579e1be36b86bfdc7c15bdf126"
+              "url": "https://blossom.swissdash.site/47f191930a544b39f7f8652d528d3ee62e61399f8928b2be3d50c55743347b0e.ipk",
+              "hash": "sha256:47f191930a544b39f7f8652d528d3ee62e61399f8928b2be3d50c55743347b0e",
+              "eventId": "69528e14c74fc42aa357bbde4a2eef0a16ab3f696da80f9ff30763fe54465fbc"
             },
             "x86_64": {
               "url": "https://blossom.swissdash.site/993aaea07198664c4da5f8dc3437514a015a6c5e488ecf43227ba0d9af5613fe.ipk",

--- a/files/etc/tollgate/release.json
+++ b/files/etc/tollgate/release.json
@@ -9,24 +9,24 @@
           "version": "0.0.1",
           "architectures": {
             "aarch64_cortex-a53": {
-              "url": "https://blossom.swissdash.site/844a1bae05b0df81ab212799f51947e6c578546a446aa7555cc8bf1a23f5928e.ipk",
-              "hash": "sha256:844a1bae05b0df81ab212799f51947e6c578546a446aa7555cc8bf1a23f5928e",
-              "eventId": "d61a3c319653263e69e68bd103f6cb83650a9f48f8b92faedd4e9f6e306685dd"
+              "url": "https://blossom.swissdash.site/dd2fbf9176dcf5e33475da53aabc5577db65eeacab9b29e7ff8698f7402449b4.ipk",
+              "hash": "sha256:dd2fbf9176dcf5e33475da53aabc5577db65eeacab9b29e7ff8698f7402449b4",
+              "eventId": "77f4243a75a67a14c30b2327b9e316eabdcd299ec8953a7f326797c7b99287b3"
             },
             "mipsel_24kc": {
-              "url": "https://blossom.swissdash.site/def9bb8442eb2136839f787c319a73645cdc9b9599defef975987277d6a1c720.ipk",
-              "hash": "sha256:def9bb8442eb2136839f787c319a73645cdc9b9599defef975987277d6a1c720",
-              "eventId": "f90ad812c20996d02b14269ee766a049d00cbd37a31268bc10a2462c75fea7aa"
+              "url": "https://blossom.swissdash.site/4c67af539b1acfc3ee49684dfccc6ccf321c6a5f8ae06c39733e038cadcea8c5.ipk",
+              "hash": "sha256:4c67af539b1acfc3ee49684dfccc6ccf321c6a5f8ae06c39733e038cadcea8c5",
+              "eventId": "8f35f72b1001f8a56c63ac7f75be30ec52d5dc5b8fe9a71360d72e1c99da33b8"
             },
             "mips_24kc": {
-              "url": "https://blossom.swissdash.site/552703627f99ff4ef6ae3169cb09dbc72eb7bcd067edc15cec534ffaf8e4ac2e.ipk",
-              "hash": "sha256:552703627f99ff4ef6ae3169cb09dbc72eb7bcd067edc15cec534ffaf8e4ac2e",
-              "eventId": "e9b8ee1e8a3c30afd544f7541f6c946238b3b33b9c016c9fa024fa21460b62ae"
+              "url": "https://blossom.swissdash.site/a68aa1d884c565141b3c27180e1b9f52c08283cc0e9558de661f94da20cf5d63.ipk",
+              "hash": "sha256:a68aa1d884c565141b3c27180e1b9f52c08283cc0e9558de661f94da20cf5d63",
+              "eventId": "3ea6fc9abde693eb09cde0f7602578a277386a4d8bb7b2e05caaf6cd3c3384bb"
             },
             "arm_cortex-a7": {
-              "url": "https://blossom.swissdash.site/39a3f511e6a37a2b45793909411db1ec5bfeba2aaa9f3891e2688338f2735257.ipk",
-              "hash": "sha256:39a3f511e6a37a2b45793909411db1ec5bfeba2aaa9f3891e2688338f2735257",
-              "eventId": "c1ee5dbd4e72a9573f5885ac88d5fa5148416ae1b5d48134bcf0a3a240bde910"
+              "url": "https://blossom.swissdash.site/9226e5bf21f6faacca618631be2ab9c54f8abef8444a9b70ed4e334d547d5fd7.ipk",
+              "hash": "sha256:9226e5bf21f6faacca618631be2ab9c54f8abef8444a9b70ed4e334d547d5fd7",
+              "eventId": "f63556711d92eea5e02f64f9a5c31f0e78143ff76494337e205f2aafb2594470"
             },
             "arm64_cortex-a53": {
               "url": "https://blossom.swissdash.site/73f0ade7daf36405e580cb7ceb8bbd93f8b35b4b74209bdd5b70eea23ffeb962.ipk",
@@ -34,9 +34,9 @@
               "eventId": "95726da9aed6fa93d2ba72ecb77de95b4b1910cade1b6c2dcd854ff5c56bd7c6"
             },
             "aarch64_cortex-a72": {
-              "url": "https://blossom.swissdash.site/13aa21af019aa143de530882bc033081108cd03b814a7d727207389e3ecb0f10.ipk",
-              "hash": "sha256:13aa21af019aa143de530882bc033081108cd03b814a7d727207389e3ecb0f10",
-              "eventId": "7bd4410a7d302a7e546576e4473ccb5a3ae73ecae1280d9f1d02885604b71754"
+              "url": "https://blossom.swissdash.site/8455c7c5116502a3bc8b496612fa8963babbbbd3d5ecbf36b4c9c9eb5f587f15.ipk",
+              "hash": "sha256:8455c7c5116502a3bc8b496612fa8963babbbbd3d5ecbf36b4c9c9eb5f587f15",
+              "eventId": "ea7879212b08234cac89572ae5ebd07e7ab07be0312cf864a19eda642fd3085d"
             }
           },
           "dependencies": []

--- a/files/etc/tollgate/release.json
+++ b/files/etc/tollgate/release.json
@@ -9,24 +9,24 @@
           "version": "0.0.1",
           "architectures": {
             "aarch64_cortex-a53": {
-              "url": "https://blossom.swissdash.site/da31fd9472928f635df5dfcddfa51068c31a4a37549392bb80cf3663b2171273.ipk",
-              "hash": "sha256:da31fd9472928f635df5dfcddfa51068c31a4a37549392bb80cf3663b2171273",
-              "eventId": "025b5ecbc1c812165ec1d3d777c48d7a76ec68812ff667b949cb376fe5469223"
+              "url": "https://blossom.swissdash.site/67371e74a72cc15441d77aa1eb2e68ed60ed24d072b4d72ef7a246cc47d773b9.ipk",
+              "hash": "sha256:67371e74a72cc15441d77aa1eb2e68ed60ed24d072b4d72ef7a246cc47d773b9",
+              "eventId": "75c5e8002dfccb2cafafba56ec2835e5686deb2894e4d811ae174d52eb945c37"
             },
             "mipsel_24kc": {
-              "url": "https://blossom.swissdash.site/63870bb329e228ff4de0fa398faf69886ac79539c52edb8441ee9ed60ec9982c.ipk",
-              "hash": "sha256:63870bb329e228ff4de0fa398faf69886ac79539c52edb8441ee9ed60ec9982c",
-              "eventId": "c3480075e53caf4573c41c9daef0319749372321038fe0189bf5ccc4618f9444"
+              "url": "https://blossom.swissdash.site/39c4b6afb8e9c5d76f15a722b94cbd0ea8e1ea1e73b1eeffd39af8f4b40a57e7.ipk",
+              "hash": "sha256:39c4b6afb8e9c5d76f15a722b94cbd0ea8e1ea1e73b1eeffd39af8f4b40a57e7",
+              "eventId": "39aafb4ad4d95bd90de4c09a6ec2ec7c6d062e9871b99e76b9cd17d5e918f03f"
             },
             "mips_24kc": {
-              "url": "https://blossom.swissdash.site/9cc05b5d36469d74d878a638c86cc5cd3177bc8525f613f087a33a68dbee6883.ipk",
-              "hash": "sha256:9cc05b5d36469d74d878a638c86cc5cd3177bc8525f613f087a33a68dbee6883",
-              "eventId": "79253a6f4cc58ac400db8a809cba3b7a31bd367d5e06bdac404ba67eae37f443"
+              "url": "https://blossom.swissdash.site/cecc8572eb779c158b48172639ed8b817e98a4731610ee459ed45b1bffb4eaa4.ipk",
+              "hash": "sha256:cecc8572eb779c158b48172639ed8b817e98a4731610ee459ed45b1bffb4eaa4",
+              "eventId": "d0e2626213024bf7d3a11e72435100a4306965e4e00d0b4b85250b06b2659e51"
             },
             "arm_cortex-a7": {
-              "url": "https://blossom.swissdash.site/6c2ac0e9a6a397cb3f7f93a046a46ef4fcb5af6b5372a5b9b0d5dabc7fc9a2df.ipk",
-              "hash": "sha256:6c2ac0e9a6a397cb3f7f93a046a46ef4fcb5af6b5372a5b9b0d5dabc7fc9a2df",
-              "eventId": "45a4cbd05f277f25934bb591767f8f6b0dfc06331c9ce5da1337a90f478c432b"
+              "url": "https://blossom.swissdash.site/7f870774bfd0a4308891b447be1a5959525d8d26c2b2d169723aae81b4ab3ca6.ipk",
+              "hash": "sha256:7f870774bfd0a4308891b447be1a5959525d8d26c2b2d169723aae81b4ab3ca6",
+              "eventId": "d951a1d5a471343d1bb580236ae0fae0db79cea24f0170687acbcc7d328eef5b"
             },
             "arm64_cortex-a53": {
               "url": "https://blossom.swissdash.site/73f0ade7daf36405e580cb7ceb8bbd93f8b35b4b74209bdd5b70eea23ffeb962.ipk",
@@ -34,9 +34,9 @@
               "eventId": "95726da9aed6fa93d2ba72ecb77de95b4b1910cade1b6c2dcd854ff5c56bd7c6"
             },
             "aarch64_cortex-a72": {
-              "url": "https://blossom.swissdash.site/3348ffdc1d2780f6f3ed1b6f6eeab7a658c5757d8c93c3b22204148e22959f82.ipk",
-              "hash": "sha256:3348ffdc1d2780f6f3ed1b6f6eeab7a658c5757d8c93c3b22204148e22959f82",
-              "eventId": "6a33c7ec3ea09de7dca15e8a1e1a7c7283d6a3e35325d239ea22d5d88a78eba4"
+              "url": "https://blossom.swissdash.site/cc0e0e54a7d15a4d8ef67454ecd90c565edd72bdd8286b5b3af83e8562598893.ipk",
+              "hash": "sha256:cc0e0e54a7d15a4d8ef67454ecd90c565edd72bdd8286b5b3af83e8562598893",
+              "eventId": "8778cffcfd55be3c38961d08ca28cbe9c711f9fb0df528cb773b7930ad90a26e"
             },
             "x86_64": {
               "url": "https://blossom.swissdash.site/993aaea07198664c4da5f8dc3437514a015a6c5e488ecf43227ba0d9af5613fe.ipk",

--- a/files/etc/tollgate/release.json
+++ b/files/etc/tollgate/release.json
@@ -9,24 +9,24 @@
           "version": "0.0.1",
           "architectures": {
             "aarch64_cortex-a53": {
-              "url": "https://blossom.swissdash.site/a7d9d4e6ccf6085ad560fc4e06960a8e5095675336df81e2c2c21eb99787901c.ipk",
-              "hash": "sha256:a7d9d4e6ccf6085ad560fc4e06960a8e5095675336df81e2c2c21eb99787901c",
-              "eventId": "8e8c4319a1f3db3572b659535ee935d47639866ddf0243d3875776c45ca0301c"
+              "url": "https://blossom.swissdash.site/d8ffa8393fe38fc0d72a95feb565a9abbb3ad73f0dc6903f333556daf8bbe8db.ipk",
+              "hash": "sha256:d8ffa8393fe38fc0d72a95feb565a9abbb3ad73f0dc6903f333556daf8bbe8db",
+              "eventId": "d260943d6d1d909a5b3dcc5aeb8616626e05084ee421f9cb1a7e71c06651e966"
             },
             "mipsel_24kc": {
-              "url": "https://blossom.swissdash.site/5c83b61c2ff5e7d00338938188b32a83d6906cecb56ab4d6b3f4804cf6558773.ipk",
-              "hash": "sha256:5c83b61c2ff5e7d00338938188b32a83d6906cecb56ab4d6b3f4804cf6558773",
-              "eventId": "061e5b8ff1a28fe1f56a0d57f4171fb329dc6b12eccbed9031072744877d5a21"
+              "url": "https://blossom.swissdash.site/1b0cf7f249f88566fdbd1899419b60729c1b5cfd322ddda8cd9e6c225a370ddb.ipk",
+              "hash": "sha256:1b0cf7f249f88566fdbd1899419b60729c1b5cfd322ddda8cd9e6c225a370ddb",
+              "eventId": "dbb6b716acc02679e112228aba1a3701412224d624fe908c68e535167d6b3610"
             },
             "mips_24kc": {
-              "url": "https://blossom.swissdash.site/089906e58207eba1aa179f0e43fbcf53fd58c733381127a55e506b67a9eb36f1.ipk",
-              "hash": "sha256:089906e58207eba1aa179f0e43fbcf53fd58c733381127a55e506b67a9eb36f1",
-              "eventId": "02e90489ede461956dd49c0d16279f9c0dd0740293e8ec109dafbced01be41c1"
+              "url": "https://blossom.swissdash.site/47d730af6008d497d3339b192dd7cd4639d8f711e0d6205f9be830b78b23f95b.ipk",
+              "hash": "sha256:47d730af6008d497d3339b192dd7cd4639d8f711e0d6205f9be830b78b23f95b",
+              "eventId": "65d63c0dd03abff0d9774a005fa1c12dca37b1cec9a615c5e555107ccc8cbdea"
             },
             "arm_cortex-a7": {
-              "url": "https://blossom.swissdash.site/34ea09adde156c2dc8bc57a8da231440b2568898f5cae581bae3f28fd78771a9.ipk",
-              "hash": "sha256:34ea09adde156c2dc8bc57a8da231440b2568898f5cae581bae3f28fd78771a9",
-              "eventId": "83b4273c1b6e6fec16dec09043959574dbfa7682a1166c0bcd9844fd712cc118"
+              "url": "https://blossom.swissdash.site/53bd56dafed6f680ef027780d69867d5514078516cb6104a8fd76e401b34c555.ipk",
+              "hash": "sha256:53bd56dafed6f680ef027780d69867d5514078516cb6104a8fd76e401b34c555",
+              "eventId": "26378565e1b32a412503f4356a8dafc63b042ef5be5e56af1afb577afaa070fa"
             },
             "arm64_cortex-a53": {
               "url": "https://blossom.swissdash.site/73f0ade7daf36405e580cb7ceb8bbd93f8b35b4b74209bdd5b70eea23ffeb962.ipk",
@@ -34,9 +34,9 @@
               "eventId": "95726da9aed6fa93d2ba72ecb77de95b4b1910cade1b6c2dcd854ff5c56bd7c6"
             },
             "aarch64_cortex-a72": {
-              "url": "https://blossom.swissdash.site/47f191930a544b39f7f8652d528d3ee62e61399f8928b2be3d50c55743347b0e.ipk",
-              "hash": "sha256:47f191930a544b39f7f8652d528d3ee62e61399f8928b2be3d50c55743347b0e",
-              "eventId": "69528e14c74fc42aa357bbde4a2eef0a16ab3f696da80f9ff30763fe54465fbc"
+              "url": "https://blossom.swissdash.site/010f0d7c1e626c7f74e004d0d35510733089028daf65ccdcc1160dfccdf774d8.ipk",
+              "hash": "sha256:010f0d7c1e626c7f74e004d0d35510733089028daf65ccdcc1160dfccdf774d8",
+              "eventId": "c61f6a93f6dbde63c6771a1fa431b5789cda5a2e4b7b01c93ecd389394eba6cb"
             },
             "x86_64": {
               "url": "https://blossom.swissdash.site/993aaea07198664c4da5f8dc3437514a015a6c5e488ecf43227ba0d9af5613fe.ipk",

--- a/files/etc/tollgate/release.json
+++ b/files/etc/tollgate/release.json
@@ -9,24 +9,24 @@
           "version": "0.0.1",
           "architectures": {
             "aarch64_cortex-a53": {
-              "url": "https://blossom.swissdash.site/67371e74a72cc15441d77aa1eb2e68ed60ed24d072b4d72ef7a246cc47d773b9.ipk",
-              "hash": "sha256:67371e74a72cc15441d77aa1eb2e68ed60ed24d072b4d72ef7a246cc47d773b9",
-              "eventId": "75c5e8002dfccb2cafafba56ec2835e5686deb2894e4d811ae174d52eb945c37"
+              "url": "https://blossom.swissdash.site/cbf390c65a4b86da6d6adbab55b806ffc368ff2acf718c7837277e876a773dfb.ipk",
+              "hash": "sha256:cbf390c65a4b86da6d6adbab55b806ffc368ff2acf718c7837277e876a773dfb",
+              "eventId": "05a1385ea2efe7846d3f41b0c2fae2f09baaffa30d8c2774f1f3d916957e4865"
             },
             "mipsel_24kc": {
-              "url": "https://blossom.swissdash.site/39c4b6afb8e9c5d76f15a722b94cbd0ea8e1ea1e73b1eeffd39af8f4b40a57e7.ipk",
-              "hash": "sha256:39c4b6afb8e9c5d76f15a722b94cbd0ea8e1ea1e73b1eeffd39af8f4b40a57e7",
-              "eventId": "39aafb4ad4d95bd90de4c09a6ec2ec7c6d062e9871b99e76b9cd17d5e918f03f"
+              "url": "https://blossom.swissdash.site/8b33ec3c3a7040709909268904af1199276750373854988b195a6e413d2c18cd.ipk",
+              "hash": "sha256:8b33ec3c3a7040709909268904af1199276750373854988b195a6e413d2c18cd",
+              "eventId": "8af4de5ab1389759edb6ae84391ef3a9bb0eaa9f7a6047730757d7e81692eaf3"
             },
             "mips_24kc": {
-              "url": "https://blossom.swissdash.site/cecc8572eb779c158b48172639ed8b817e98a4731610ee459ed45b1bffb4eaa4.ipk",
-              "hash": "sha256:cecc8572eb779c158b48172639ed8b817e98a4731610ee459ed45b1bffb4eaa4",
-              "eventId": "d0e2626213024bf7d3a11e72435100a4306965e4e00d0b4b85250b06b2659e51"
+              "url": "https://blossom.swissdash.site/7be6695f7d33831dbd214fbafef386709c6d26868d5b68d61eea919fb0ecfdef.ipk",
+              "hash": "sha256:7be6695f7d33831dbd214fbafef386709c6d26868d5b68d61eea919fb0ecfdef",
+              "eventId": "57a24e427b834db942666d1c238b14147feaef8012e1d9a72d7ba2c6c87d6b1d"
             },
             "arm_cortex-a7": {
-              "url": "https://blossom.swissdash.site/7f870774bfd0a4308891b447be1a5959525d8d26c2b2d169723aae81b4ab3ca6.ipk",
-              "hash": "sha256:7f870774bfd0a4308891b447be1a5959525d8d26c2b2d169723aae81b4ab3ca6",
-              "eventId": "d951a1d5a471343d1bb580236ae0fae0db79cea24f0170687acbcc7d328eef5b"
+              "url": "https://blossom.swissdash.site/c95e49697f3de7e60b3d63ac00b79fe14b6385827410f998b32126526edd04b5.ipk",
+              "hash": "sha256:c95e49697f3de7e60b3d63ac00b79fe14b6385827410f998b32126526edd04b5",
+              "eventId": "8c806949dfe4049eaca2a4487bdb8592ef6bed583fcc2ffceb636d9fc97c5f7b"
             },
             "arm64_cortex-a53": {
               "url": "https://blossom.swissdash.site/73f0ade7daf36405e580cb7ceb8bbd93f8b35b4b74209bdd5b70eea23ffeb962.ipk",
@@ -34,9 +34,9 @@
               "eventId": "95726da9aed6fa93d2ba72ecb77de95b4b1910cade1b6c2dcd854ff5c56bd7c6"
             },
             "aarch64_cortex-a72": {
-              "url": "https://blossom.swissdash.site/cc0e0e54a7d15a4d8ef67454ecd90c565edd72bdd8286b5b3af83e8562598893.ipk",
-              "hash": "sha256:cc0e0e54a7d15a4d8ef67454ecd90c565edd72bdd8286b5b3af83e8562598893",
-              "eventId": "8778cffcfd55be3c38961d08ca28cbe9c711f9fb0df528cb773b7930ad90a26e"
+              "url": "https://blossom.swissdash.site/e8362180b67e6999079e7dbf760f68342b6ef6d922dd523046f36dc54cc7e361.ipk",
+              "hash": "sha256:e8362180b67e6999079e7dbf760f68342b6ef6d922dd523046f36dc54cc7e361",
+              "eventId": "b8893136050433357585e6264c0fe15f43ca7547f3a35d09dde168f43357e4ef"
             },
             "x86_64": {
               "url": "https://blossom.swissdash.site/993aaea07198664c4da5f8dc3437514a015a6c5e488ecf43227ba0d9af5613fe.ipk",
@@ -47,6 +47,31 @@
               "url": "https://blossom.swissdash.site/4a3b4587d72f9038f088d569227b765ac919c002cbebecfbe7332ceabdbf142e.ipk",
               "hash": "sha256:4a3b4587d72f9038f088d569227b765ac919c002cbebecfbe7332ceabdbf142e",
               "eventId": "9a394de78f6285dfda850ed0b4cbbbdd979fd5c041e4ae6059bc68bb9f9cd38a"
+            },
+            "aarch64_cortex-a53-upx-compressed": {
+              "url": "https://blossom.swissdash.site/7a0b827c417b56c2e8b0ed71e593eed13af9b2a9da0504861e72d66c2fe0ffc7.ipk",
+              "hash": "sha256:7a0b827c417b56c2e8b0ed71e593eed13af9b2a9da0504861e72d66c2fe0ffc7",
+              "eventId": "9d86fc43459a150153aff745a5cfc7c514b3c9ef6d7eacbc29b9591ed577f8fc"
+            },
+            "aarch64_cortex-a72-upx-compressed": {
+              "url": "https://blossom.swissdash.site/00cf2917656fb3e89acc2116c021f4478e1bdcde7957fc972023bf8f9f4db16e.ipk",
+              "hash": "sha256:00cf2917656fb3e89acc2116c021f4478e1bdcde7957fc972023bf8f9f4db16e",
+              "eventId": "bc7ed169831b31fa5d2cfeebb66dbe91776167a183516adeffe0cdf81cdd3432"
+            },
+            "mipsel_24kc-upx-compressed": {
+              "url": "https://blossom.swissdash.site/f4dd96b07ff87f52d93a92774fa2297dce9c3f3e1161afada809f9b85bb14e72.ipk",
+              "hash": "sha256:f4dd96b07ff87f52d93a92774fa2297dce9c3f3e1161afada809f9b85bb14e72",
+              "eventId": "0efbc9ef6974b180c3458297f25a8e130705a5610feb2e002e79eb9aa7529817"
+            },
+            "mips_24kc-upx-compressed": {
+              "url": "https://blossom.swissdash.site/145e15f505fa234e7f584114b8231f568c675f90a2bc86799b79f428d0a9aada.ipk",
+              "hash": "sha256:145e15f505fa234e7f584114b8231f568c675f90a2bc86799b79f428d0a9aada",
+              "eventId": "803a05d1128a09467f9c16c3f3b1b954be0ef3567556d4985866928e3228f805"
+            },
+            "arm_cortex-a7-upx-compressed": {
+              "url": "https://blossom.swissdash.site/4b3995b1b0b414f29748e43e3ba90d603d760acef84c71a65b1f05c9b31642d8.ipk",
+              "hash": "sha256:4b3995b1b0b414f29748e43e3ba90d603d760acef84c71a65b1f05c9b31642d8",
+              "eventId": "36592d606de12de2ace7b9456b811097438f51f6df813e071622aa9d85687e10"
             }
           },
           "dependencies": []

--- a/files/etc/tollgate/release.json
+++ b/files/etc/tollgate/release.json
@@ -9,24 +9,24 @@
           "version": "0.0.1",
           "architectures": {
             "aarch64_cortex-a53": {
-              "url": "https://blossom.swissdash.site/793df2e2199a78a92e69b7c42ba8bad85931e01d10f1d528ad193a637d7438a3.ipk",
-              "hash": "sha256:793df2e2199a78a92e69b7c42ba8bad85931e01d10f1d528ad193a637d7438a3",
-              "eventId": "114696da50146f94072f022abd4d88527f947a03d4116b23f37f436f46eecf9f"
+              "url": "https://blossom.swissdash.site/f3ed93ffbf992487d9233e7368f9e2c3271145c19e5d1c10c0a9f46a2c1d0838.ipk",
+              "hash": "sha256:f3ed93ffbf992487d9233e7368f9e2c3271145c19e5d1c10c0a9f46a2c1d0838",
+              "eventId": "1ebc7c227236baaada06c6976f5d2f412802261fbae6c87abcaab0832e13518e"
             },
             "mipsel_24kc": {
-              "url": "https://blossom.swissdash.site/73b8b6dac0bf3e1c0fe13c5eb1ed85c133e823e17498a5f6abb47ecd8c6e9541.ipk",
-              "hash": "sha256:73b8b6dac0bf3e1c0fe13c5eb1ed85c133e823e17498a5f6abb47ecd8c6e9541",
-              "eventId": "1794f24cde130a88fe55740172740340ddcf4c670610924f342da3726612bfce"
+              "url": "https://blossom.swissdash.site/8f9f1a9cee95927227e45359722f43666b02297b134d52423fc3ddc6e266ab36.ipk",
+              "hash": "sha256:8f9f1a9cee95927227e45359722f43666b02297b134d52423fc3ddc6e266ab36",
+              "eventId": "4bc6c645b1679482b49fd70b6792c8b306962e3ee4a36eb5259c4edf08766350"
             },
             "mips_24kc": {
-              "url": "https://blossom.swissdash.site/249daff55f387bc394d8b0403ac601e85eb907635ddee3c66b4a589744ae60ef.ipk",
-              "hash": "sha256:249daff55f387bc394d8b0403ac601e85eb907635ddee3c66b4a589744ae60ef",
-              "eventId": "40b36d6a5e4d27bbd1c5b064ea1ac226bed15f0d9d8c896e3842e99702bc88a0"
+              "url": "https://blossom.swissdash.site/8a34708d6daee9e57f1d5b6c66816c417b57c673e90dd053389c20be352c0ab1.ipk",
+              "hash": "sha256:8a34708d6daee9e57f1d5b6c66816c417b57c673e90dd053389c20be352c0ab1",
+              "eventId": "56bc8948707b795d448e6e5da4c8dd9411dc67e3ed3dd6fd94a0c561e0481d11"
             },
             "arm_cortex-a7": {
-              "url": "https://blossom.swissdash.site/66e0c8d41a66f89985f13ed1fe146c0b29db5714ef0b517c07c044facaf8b02a.ipk",
-              "hash": "sha256:66e0c8d41a66f89985f13ed1fe146c0b29db5714ef0b517c07c044facaf8b02a",
-              "eventId": "b66e2e58712db6b2692dcb5b9da7f3bb8ec09c453bbc94a9ce8bed31f7fb5c72"
+              "url": "https://blossom.swissdash.site/5d354cd330cccae80f063761353557bff406a611c86b873ad8a46be7e1fe4069.ipk",
+              "hash": "sha256:5d354cd330cccae80f063761353557bff406a611c86b873ad8a46be7e1fe4069",
+              "eventId": "bd93fac16ef2427dbfd91cc6c8ff858013fc4eb590764b8339c464f92f946322"
             },
             "arm64_cortex-a53": {
               "url": "https://blossom.swissdash.site/73f0ade7daf36405e580cb7ceb8bbd93f8b35b4b74209bdd5b70eea23ffeb962.ipk",
@@ -34,9 +34,9 @@
               "eventId": "95726da9aed6fa93d2ba72ecb77de95b4b1910cade1b6c2dcd854ff5c56bd7c6"
             },
             "aarch64_cortex-a72": {
-              "url": "https://blossom.swissdash.site/287e740d0964a4a26dcc65b862f228d9fc1d1a8ec6b87afe5507188ff7de697c.ipk",
-              "hash": "sha256:287e740d0964a4a26dcc65b862f228d9fc1d1a8ec6b87afe5507188ff7de697c",
-              "eventId": "fb394912f883b5f6f9b63ec0f8b569ca1613169255fce473140e91c703e04f1b"
+              "url": "https://blossom.swissdash.site/312eb5e4051968801d4134c1cfe1c99cd36b2711ec87344130bc78d191d30c06.ipk",
+              "hash": "sha256:312eb5e4051968801d4134c1cfe1c99cd36b2711ec87344130bc78d191d30c06",
+              "eventId": "3270e0d178dca767c4ef8952ec2d53557a8fc00dcccfd9f61c0fa218b21cf600"
             }
           },
           "dependencies": []

--- a/files/etc/tollgate/release.json
+++ b/files/etc/tollgate/release.json
@@ -9,24 +9,24 @@
           "version": "0.0.1",
           "architectures": {
             "aarch64_cortex-a53": {
-              "url": "https://blossom.swissdash.site/a1b55ed2f4c821ec5057376fe6dda2c84a3e7786bac72aac08c2b51e28262c61.ipk",
-              "hash": "sha256:a1b55ed2f4c821ec5057376fe6dda2c84a3e7786bac72aac08c2b51e28262c61",
-              "eventId": "8cb4f150927b748ae69e1eb5b9d1113a3b6438b4eda570b69177017108952606"
+              "url": "https://blossom.swissdash.site/7ed3df4d4b8defbe21da0946f37be34ffc4d25c726a545ab7d8f908c0cb2a82e.ipk",
+              "hash": "sha256:7ed3df4d4b8defbe21da0946f37be34ffc4d25c726a545ab7d8f908c0cb2a82e",
+              "eventId": "bd069fdb01a639084e25e447187a556760bfb077d6cc29c2a4990d706d7369e2"
             },
             "mipsel_24kc": {
-              "url": "https://blossom.swissdash.site/669c697ce733097bb5d586fee95a5d4c7cf91830670e1a21bae1670834fb240a.ipk",
-              "hash": "sha256:669c697ce733097bb5d586fee95a5d4c7cf91830670e1a21bae1670834fb240a",
-              "eventId": "2e64b2af13682145cf0dad1aa3c1df084399b155d818ab291dc3cedd5ddd81a5"
+              "url": "https://blossom.swissdash.site/4de4981964ad98d408804ebeba552034ce34d375cc498c24b7b0c8c54788cbdd.ipk",
+              "hash": "sha256:4de4981964ad98d408804ebeba552034ce34d375cc498c24b7b0c8c54788cbdd",
+              "eventId": "17140dd340aa5cc7852e9e97a77959b1a5c4b31a92b91089deb36256d2446120"
             },
             "mips_24kc": {
-              "url": "https://blossom.swissdash.site/047662c9112ff33e59d41adc1d00e467bc5319f9487d3173e2f8e3384acb6089.ipk",
-              "hash": "sha256:047662c9112ff33e59d41adc1d00e467bc5319f9487d3173e2f8e3384acb6089",
-              "eventId": "835eb40cb2051e0d28e9a4ba25012349241afb07d81385647dd6a5057c6012a4"
+              "url": "https://blossom.swissdash.site/f6d58bb24c67fd9c2ceb37dfd61b78b003a6baf3daff91e07a3859e80d69b53c.ipk",
+              "hash": "sha256:f6d58bb24c67fd9c2ceb37dfd61b78b003a6baf3daff91e07a3859e80d69b53c",
+              "eventId": "932965da2ec7406036942a45620d7cda44b5eef559ded11e123afe54ada2fb78"
             },
             "arm_cortex-a7": {
-              "url": "https://blossom.swissdash.site/bfdb2ea1fc863535c54e7067b943f48097ee76bb0a332dc45e502aa884f554a9.ipk",
-              "hash": "sha256:bfdb2ea1fc863535c54e7067b943f48097ee76bb0a332dc45e502aa884f554a9",
-              "eventId": "814a628d3abc1fd1f6308618560db54998ff9836b8aedaae1e7f5f6de3ab54a4"
+              "url": "https://blossom.swissdash.site/7318e3d7bb31222c0415e5ccc1f6775f1cef4a8467732ac2e67d0c74fe2404e8.ipk",
+              "hash": "sha256:7318e3d7bb31222c0415e5ccc1f6775f1cef4a8467732ac2e67d0c74fe2404e8",
+              "eventId": "7171497749058c2db1b01fe7f04d84bd455948643b6b4b3752a8cc0427abccfa"
             },
             "arm64_cortex-a53": {
               "url": "https://blossom.swissdash.site/73f0ade7daf36405e580cb7ceb8bbd93f8b35b4b74209bdd5b70eea23ffeb962.ipk",
@@ -34,9 +34,9 @@
               "eventId": "95726da9aed6fa93d2ba72ecb77de95b4b1910cade1b6c2dcd854ff5c56bd7c6"
             },
             "aarch64_cortex-a72": {
-              "url": "https://blossom.swissdash.site/cb0b2620bae3acff44dd0b146360d9ff26d575af4d5db8c54258dd666d86d8de.ipk",
-              "hash": "sha256:cb0b2620bae3acff44dd0b146360d9ff26d575af4d5db8c54258dd666d86d8de",
-              "eventId": "4cdb17e070b08184b43968bc3d276da1553e2773f7f43f495925fb261ed62595"
+              "url": "https://blossom.swissdash.site/79980124c0e09e3cf11a4457194a8f9969e62b3f90a60918fd7871aa5da6c590.ipk",
+              "hash": "sha256:79980124c0e09e3cf11a4457194a8f9969e62b3f90a60918fd7871aa5da6c590",
+              "eventId": "ccc31cb0f0b1bb621434a9b6ad78e7c76121f661b4c30784599cb2a3a61fa0b6"
             }
           },
           "dependencies": []

--- a/files/etc/tollgate/release.json
+++ b/files/etc/tollgate/release.json
@@ -9,24 +9,24 @@
           "version": "0.0.1",
           "architectures": {
             "aarch64_cortex-a53": {
-              "url": "https://blossom.swissdash.site/8710737bf67b90518b480f9ffa5b55aaa7bf397169074c389c7905b680f70459.ipk",
-              "hash": "sha256:8710737bf67b90518b480f9ffa5b55aaa7bf397169074c389c7905b680f70459",
-              "eventId": "3a615d238fb795c58d4b9f96c24b5b5d174b355cb8cf86e884982a1bc76746f7"
+              "url": "https://blossom.swissdash.site/01749491ea7b6c2eaf5e36db4e76c3a86c38bdba35dcfad509d06f8d0ecadd02.ipk",
+              "hash": "sha256:01749491ea7b6c2eaf5e36db4e76c3a86c38bdba35dcfad509d06f8d0ecadd02",
+              "eventId": "78bfab06e5f356e4c69e57f7c6425f9c0bbe55bd50d18502de58897f0054713d"
             },
             "mipsel_24kc": {
-              "url": "https://blossom.swissdash.site/d335395d05de4240b0d3c4707136fc9fddfb352dc47a7281db67f64c91de680e.ipk",
-              "hash": "sha256:d335395d05de4240b0d3c4707136fc9fddfb352dc47a7281db67f64c91de680e",
-              "eventId": "1151fae2229fdb5258d32a19a1fc3620dec836673c3c2911557d07bdb571ebff"
+              "url": "https://blossom.swissdash.site/afd9da23ab2ae267803d2f7839a57432ecb1d60e678e13431ebea66d2291e630.ipk",
+              "hash": "sha256:afd9da23ab2ae267803d2f7839a57432ecb1d60e678e13431ebea66d2291e630",
+              "eventId": "1af05e2c373ce2ca55556fc90912df20ce598d44ab74f353f697766c6e2c4c75"
             },
             "mips_24kc": {
-              "url": "https://blossom.swissdash.site/cf7c6272e57415d13efb4b48df3d86d79767c32a1ef2186466024abbbf2235f0.ipk",
-              "hash": "sha256:cf7c6272e57415d13efb4b48df3d86d79767c32a1ef2186466024abbbf2235f0",
-              "eventId": "683dfe0aca3eb041135a17f9122421bffa8d2f88cdfde068495548bc7c4802a9"
+              "url": "https://blossom.swissdash.site/2803919152bb8a736de70e8b22cbe495051e9b73e399b039fb59ab05a27cc10b.ipk",
+              "hash": "sha256:2803919152bb8a736de70e8b22cbe495051e9b73e399b039fb59ab05a27cc10b",
+              "eventId": "c58485273adbe36dd7fd0436e452512743c21ef194ddf0a999642ddf3f0c40b2"
             },
             "arm_cortex-a7": {
-              "url": "https://blossom.swissdash.site/5fc4635784a532033c5331231b539408a0d414ad381370df85d66cf5180c8a2b.ipk",
-              "hash": "sha256:5fc4635784a532033c5331231b539408a0d414ad381370df85d66cf5180c8a2b",
-              "eventId": "4d8b28cf9e5e0773b59bc84b05b2ec3241ebe6eb9ba1e9f560a5e74d5ea25744"
+              "url": "https://blossom.swissdash.site/212ae5f8f336e2eacda6cbf18881427ad9496746b01d5b74b951aafd99119361.ipk",
+              "hash": "sha256:212ae5f8f336e2eacda6cbf18881427ad9496746b01d5b74b951aafd99119361",
+              "eventId": "1038e1bc8f1d0e1912b2b4f7aad04e3c93537e9811318b21f01e664b2d0be3fd"
             },
             "arm64_cortex-a53": {
               "url": "https://blossom.swissdash.site/73f0ade7daf36405e580cb7ceb8bbd93f8b35b4b74209bdd5b70eea23ffeb962.ipk",
@@ -34,9 +34,9 @@
               "eventId": "95726da9aed6fa93d2ba72ecb77de95b4b1910cade1b6c2dcd854ff5c56bd7c6"
             },
             "aarch64_cortex-a72": {
-              "url": "https://blossom.swissdash.site/eee36538159682456c5eb6c63bf54a9e6f4b41914cf8c91df6d76726a62f540d.ipk",
-              "hash": "sha256:eee36538159682456c5eb6c63bf54a9e6f4b41914cf8c91df6d76726a62f540d",
-              "eventId": "48d352710f2be34f2ec1913be0fc234753f1bc5366b41b034774f72aca8bf39f"
+              "url": "https://blossom.swissdash.site/beb8adeb4976625170aad3f3145a42379e46980636cf3ead16c94abd0bf300f1.ipk",
+              "hash": "sha256:beb8adeb4976625170aad3f3145a42379e46980636cf3ead16c94abd0bf300f1",
+              "eventId": "b34ddfda5464e277cd1c5ad95c236cdfcb459a70205df146b77fa6c8ced41943"
             }
           },
           "dependencies": []

--- a/files/etc/tollgate/release.json
+++ b/files/etc/tollgate/release.json
@@ -9,24 +9,24 @@
           "version": "0.0.1",
           "architectures": {
             "aarch64_cortex-a53": {
-              "url": "https://blossom.swissdash.site/427bf4cf7800f4b9680d5a73f6c652938dda55adc8d47a9dd2996388d31d9263.ipk",
-              "hash": "sha256:427bf4cf7800f4b9680d5a73f6c652938dda55adc8d47a9dd2996388d31d9263",
-              "eventId": "3741822787976e0d8db3eae552b92cf46f2ef1eb7c44b3c836b4525999945c7c"
+              "url": "https://blossom.swissdash.site/050227a82c165f9c57899956c6c15392803d75ad73f30fd6a4aa645fee01a61e.ipk",
+              "hash": "sha256:050227a82c165f9c57899956c6c15392803d75ad73f30fd6a4aa645fee01a61e",
+              "eventId": "96e70043f4bcedb95eb6882cb6b00baadd20d73cf8b347b297faf1afc1aaa7b0"
             },
             "mipsel_24kc": {
-              "url": "https://blossom.swissdash.site/5c258d55517704c68b7c2ac4a1cf27da1acd12a9432157dcf1d372d3b8a8a514.ipk",
-              "hash": "sha256:5c258d55517704c68b7c2ac4a1cf27da1acd12a9432157dcf1d372d3b8a8a514",
-              "eventId": "fba71f406b7e8655f25642403611d4cabea010edd20ae4bab57719117fe2ad2e"
+              "url": "https://blossom.swissdash.site/1edb10f260c1aae07b413bdd0298c320bd697e118a020fb42228a0b3f9d04d46.ipk",
+              "hash": "sha256:1edb10f260c1aae07b413bdd0298c320bd697e118a020fb42228a0b3f9d04d46",
+              "eventId": "69be04efea83f218cefa7f928cd0c8aea4ffc1e44d174d06e21293e6199713f7"
             },
             "mips_24kc": {
-              "url": "https://blossom.swissdash.site/46daa5db18685c4b126b652ebe12090d3a76a90e1e37ad7f325af5da20ab4083.ipk",
-              "hash": "sha256:46daa5db18685c4b126b652ebe12090d3a76a90e1e37ad7f325af5da20ab4083",
-              "eventId": "780fa3358e9f94d6f1ced7ec65f574aefee4ca1308e8bd7e2210f79a23ecd707"
+              "url": "https://blossom.swissdash.site/649cb2b378036a0cedd293211e9dd32a18cbe52e4440a47f35d815101f5fb1ab.ipk",
+              "hash": "sha256:649cb2b378036a0cedd293211e9dd32a18cbe52e4440a47f35d815101f5fb1ab",
+              "eventId": "7cfa17865b55aebfac698ad9c80ef1e6b294130b488aac77e9d10aed7ce55d5f"
             },
             "arm_cortex-a7": {
-              "url": "https://blossom.swissdash.site/96dfda781d65832192f373a50352c0e5805f5afb71bd0def3913d7b4dad2acb7.ipk",
-              "hash": "sha256:96dfda781d65832192f373a50352c0e5805f5afb71bd0def3913d7b4dad2acb7",
-              "eventId": "5945144d728469447293cf755943e21cee88eb18cf32e7dedb092080a72fe917"
+              "url": "https://blossom.swissdash.site/a869c76660b5141de60f0945812618ee7f6cedcd0eb27e8d4136e294bace2347.ipk",
+              "hash": "sha256:a869c76660b5141de60f0945812618ee7f6cedcd0eb27e8d4136e294bace2347",
+              "eventId": "45f60de619a67223bb92a35855b380d6ff6c5cb6ebf784d0b7948ba47f78ce9a"
             },
             "arm64_cortex-a53": {
               "url": "https://blossom.swissdash.site/73f0ade7daf36405e580cb7ceb8bbd93f8b35b4b74209bdd5b70eea23ffeb962.ipk",
@@ -34,9 +34,9 @@
               "eventId": "95726da9aed6fa93d2ba72ecb77de95b4b1910cade1b6c2dcd854ff5c56bd7c6"
             },
             "aarch64_cortex-a72": {
-              "url": "https://blossom.swissdash.site/c680b3be63396970c8787148a4d83096a19cbe143cd5abd366750e115d0f5062.ipk",
-              "hash": "sha256:c680b3be63396970c8787148a4d83096a19cbe143cd5abd366750e115d0f5062",
-              "eventId": "c6cdf9cc58bac4e3c13ceb0281716e55a509f13d12b537074dc32aff26541272"
+              "url": "https://blossom.swissdash.site/afd0bdf0ed4503842290d408af5469521f72f2846663566b701ff7163232ab69.ipk",
+              "hash": "sha256:afd0bdf0ed4503842290d408af5469521f72f2846663566b701ff7163232ab69",
+              "eventId": "e2ad1ba073f0193367b3c5470b24253ccc2cdef2cda1b6e36f883df950dacdd4"
             }
           },
           "dependencies": []

--- a/files/etc/tollgate/release.json
+++ b/files/etc/tollgate/release.json
@@ -9,24 +9,24 @@
           "version": "0.0.1",
           "architectures": {
             "aarch64_cortex-a53": {
-              "url": "https://blossom.swissdash.site/dd2fbf9176dcf5e33475da53aabc5577db65eeacab9b29e7ff8698f7402449b4.ipk",
-              "hash": "sha256:dd2fbf9176dcf5e33475da53aabc5577db65eeacab9b29e7ff8698f7402449b4",
-              "eventId": "77f4243a75a67a14c30b2327b9e316eabdcd299ec8953a7f326797c7b99287b3"
+              "url": "https://blossom.swissdash.site/17bd83ca9284b8ce317a627647dd69db02bd6d83385c08a1b4dc04bdd83e7ecb.ipk",
+              "hash": "sha256:17bd83ca9284b8ce317a627647dd69db02bd6d83385c08a1b4dc04bdd83e7ecb",
+              "eventId": "970d1c8070a277db63676112a0804a89e8f577ec4e80d692204397cddb5eb930"
             },
             "mipsel_24kc": {
-              "url": "https://blossom.swissdash.site/4c67af539b1acfc3ee49684dfccc6ccf321c6a5f8ae06c39733e038cadcea8c5.ipk",
-              "hash": "sha256:4c67af539b1acfc3ee49684dfccc6ccf321c6a5f8ae06c39733e038cadcea8c5",
-              "eventId": "8f35f72b1001f8a56c63ac7f75be30ec52d5dc5b8fe9a71360d72e1c99da33b8"
+              "url": "https://blossom.swissdash.site/9298db0ee5655c29c80d9ea3123df00747b4e53b9dcd472bc901434bc70697bf.ipk",
+              "hash": "sha256:9298db0ee5655c29c80d9ea3123df00747b4e53b9dcd472bc901434bc70697bf",
+              "eventId": "16deb2697f5bb1fd1a66f64c348386ea159e857f8e3deb7683be11acbc66e5ee"
             },
             "mips_24kc": {
-              "url": "https://blossom.swissdash.site/a68aa1d884c565141b3c27180e1b9f52c08283cc0e9558de661f94da20cf5d63.ipk",
-              "hash": "sha256:a68aa1d884c565141b3c27180e1b9f52c08283cc0e9558de661f94da20cf5d63",
-              "eventId": "3ea6fc9abde693eb09cde0f7602578a277386a4d8bb7b2e05caaf6cd3c3384bb"
+              "url": "https://blossom.swissdash.site/18511620258a7ff3a513da09349164e121468a1e8e69b6cb533289957c8333a4.ipk",
+              "hash": "sha256:18511620258a7ff3a513da09349164e121468a1e8e69b6cb533289957c8333a4",
+              "eventId": "7b71e83644f848102b407b2656eba014790555b304b32e823737fe98611405dd"
             },
             "arm_cortex-a7": {
-              "url": "https://blossom.swissdash.site/9226e5bf21f6faacca618631be2ab9c54f8abef8444a9b70ed4e334d547d5fd7.ipk",
-              "hash": "sha256:9226e5bf21f6faacca618631be2ab9c54f8abef8444a9b70ed4e334d547d5fd7",
-              "eventId": "f63556711d92eea5e02f64f9a5c31f0e78143ff76494337e205f2aafb2594470"
+              "url": "https://blossom.swissdash.site/aa49a21c5b55ac4f41ee9ee2ad731532f108145c416f66f67c17ebe43b41c254.ipk",
+              "hash": "sha256:aa49a21c5b55ac4f41ee9ee2ad731532f108145c416f66f67c17ebe43b41c254",
+              "eventId": "07f7d5dac8af8fe990301b39b67b916c1351d0279737fd8fce374cbb03f13b6f"
             },
             "arm64_cortex-a53": {
               "url": "https://blossom.swissdash.site/73f0ade7daf36405e580cb7ceb8bbd93f8b35b4b74209bdd5b70eea23ffeb962.ipk",
@@ -34,9 +34,19 @@
               "eventId": "95726da9aed6fa93d2ba72ecb77de95b4b1910cade1b6c2dcd854ff5c56bd7c6"
             },
             "aarch64_cortex-a72": {
-              "url": "https://blossom.swissdash.site/8455c7c5116502a3bc8b496612fa8963babbbbd3d5ecbf36b4c9c9eb5f587f15.ipk",
-              "hash": "sha256:8455c7c5116502a3bc8b496612fa8963babbbbd3d5ecbf36b4c9c9eb5f587f15",
-              "eventId": "ea7879212b08234cac89572ae5ebd07e7ab07be0312cf864a19eda642fd3085d"
+              "url": "https://blossom.swissdash.site/681dd348406f6318ae70cce8e6545f71218abc1f8809d88cd3231c474d8e189f.ipk",
+              "hash": "sha256:681dd348406f6318ae70cce8e6545f71218abc1f8809d88cd3231c474d8e189f",
+              "eventId": "d45a43921531271a2e86ede0c2b3b863b9dad6579e1be36b86bfdc7c15bdf126"
+            },
+            "x86_64": {
+              "url": "https://blossom.swissdash.site/993aaea07198664c4da5f8dc3437514a015a6c5e488ecf43227ba0d9af5613fe.ipk",
+              "hash": "sha256:993aaea07198664c4da5f8dc3437514a015a6c5e488ecf43227ba0d9af5613fe",
+              "eventId": "c4f73aebaeebc8bbbefd6b64ef068402269933c03fe97b4808c3c30c02eb2e26"
+            },
+            "i386_pentium4": {
+              "url": "https://blossom.swissdash.site/4a3b4587d72f9038f088d569227b765ac919c002cbebecfbe7332ceabdbf142e.ipk",
+              "hash": "sha256:4a3b4587d72f9038f088d569227b765ac919c002cbebecfbe7332ceabdbf142e",
+              "eventId": "9a394de78f6285dfda850ed0b4cbbbdd979fd5c041e4ae6059bc68bb9f9cd38a"
             }
           },
           "dependencies": []


### PR DESCRIPTION
# TollGate v0.3.0 Release Notes

**Release Date:** 12-nov-2025  
**Release Type:** Feature Release

## Overview

Version 0.3.0 introduces a private network feature alongside CLI management tools, enhancing TollGate's network management capabilities and user experience.

---

## 🎉 New Features

### Private Network (Secure SSID)

TollGate now automatically creates a secure, password-protected private network alongside the public captive portal network. This provides administrators with secure access to the router without going through the captive portal. Allowing them to use their tollgate just like any other private network.

**Key Features:**
- **Automatic Setup**: Private network is configured automatically during installation
- **Unified SSID**: Both 2.4GHz and 5GHz bands broadcast the same SSID for seamless roaming
- **Human-Readable Passwords**: Automatically generated memorable passwords using NATO phonetic alphabet (e.g., `Hotel-Sierra-Kilo-42`)
- **Separate Network Segment**: Private network operates on its own subnet with dedicated firewall zone
- **Full Internet Access**: Private network has unrestricted access to WAN

**Network Configuration:**
- **SSID Format**: `c03rad0r-{RANDOM_SUFFIX}` (matches the router's unique identifier)
- **Encryption**: WPA2-PSK (CCMP)
- **IP Range**: Automatically derived from LAN IP (adjacent subnet)
- **DHCP**: 150 addresses available (100-250)

### CLI Network Management Commands

New `tollgate network private` command suite for managing the private network:

#### `tollgate network private status`
Displays current private network configuration in a clean, formatted view:
```
Private Network Configuration
=============================
SSID:     c03rad0r-DXEL
Password: Hotel-Sierra-Kilo-42
Status:   Enabled
```

#### `tollgate network private enable`
Enables the private network on both 2.4GHz and 5GHz radios.

#### `tollgate network private disable`
Disables the private network with safety confirmation to prevent accidental lockout:
```
⚠️  WARNING: Disabling the private network may lock you out of the router!
Make sure you have another way to access the router.

Are you sure you want to disable the private network? (y/N):
```

#### `tollgate network private rename [new-ssid]`
Changes the SSID of the private network:
```bash
tollgate network private rename my-secure-network
```

#### `tollgate network private set-password [password]`
Sets a new password for the private network. If no password is provided, generates a random memorable password:
```bash
# Set specific password
tollgate network private set-password MySecurePass123

# Generate random password
tollgate network private set-password
```

---

## 🔧 Technical Improvements

### Password Generation
- Uses `hexdump` with `/dev/urandom` for cryptographic-quality randomness
- POSIX-compliant shell implementation for OpenWrt compatibility
- Generates passwords in format: `Word1-Word2-Word3-##` (e.g., `Alpha-Bravo-Charlie-42`)
- Passwords meet WPA2 requirements (8-63 characters)

### Network Architecture
- Private network uses dedicated bridge interface (`br-private`)
- Separate firewall zone with full forwarding to WAN
- Independent DHCP server configuration
- Automatic network reload after configuration changes

### CLI Infrastructure
- New `network.go` module for network management operations
- UCI integration for wireless configuration
- Graceful error handling for missing configurations
- Version information package for proper build-time version injection

---

## 📝 Configuration Files

### New Files
- `files/etc/uci-defaults/99b-tollgate-setup-private-ssid` - Private network setup script
- `src/cli/network.go` - Network management CLI handlers
- `src/version/version.go` - Version information package

### Modified Files
- `src/cmd/tollgate-cli/main.go` - Added network management commands
- `src/cli/server.go` - Added network command routing
- `src/cli/types.go` - Added `PrivateNetworkInfo` type

---

## 🔒 Security Considerations

- Private network uses WPA2-PSK encryption by default
- Passwords are automatically generated
- Disable command includes confirmation prompt to prevent accidental lockout
- Private network has separate firewall zone for security isolation

---

## 📚 Usage Examples

### Check Private Network Status
```bash
tollgate network private status
```

### Change Private Network Name
```bash
tollgate network private rename office-wifi
```

### Generate New Random Password
```bash
tollgate network private set-password
# Output: Private network password changed successfully
#         new_password: Tango-Echo-Victor-87
```

### Temporarily Disable Private Network
```bash
tollgate network private disable
# Prompts for confirmation before disabling
```

---

## ⚠️ Breaking Changes

None. This release is fully backward compatible with v0.2.0

---

## 🐛 Known Issues / limitations

- Private network 5GHz interface may be disabled if radio1 is in client mode (reseller mode)
- Password must be set manually via CLI if setup script fails during installation

---

## 📦 Installation & Upgrade

### Fresh Installation
The private network is automatically configured during first boot via UCI defaults script.

### Upgrade from Previous Versions
When upgrading from v0.2.0 or earlier:
1. The private network will be automatically configured on first boot after upgrade
2. Check the generated password: `tollgate network private status`
3. Optionally customize the SSID or password using the CLI commands

---

## 🙏 Acknowledgments

Special thanks to the community for feedback on network management and security features.

---

**Full Changelog**: https://github.com/OpenTollGate/tollgate-module-basic-go/compare/v0.2.0...v0.3.0