### PR TITLE
fix(firstboot): retry NTP sync until clock is confirmed synced once

### DIFF
--- a/files/etc/init.d/tollgate-timesync
+++ b/files/etc/init.d/tollgate-timesync
@@ -1,0 +1,33 @@
+#!/bin/sh /etc/rc.common
+# TollGate first-boot NTP sync.
+# Retries ntpd -q in the background until one successful sync ever, then
+# marks /etc/tollgate_timesynced and stays a no-op on subsequent boots.
+# Fixes https://github.com/OpenTollGate/tollgate-module-basic-go/issues/42
+# — Cashu token validation needs a sane clock, and sysfixtime leaves a
+# fresh flash at the firmware build date until sysntpd catches up.
+
+START=45
+STOP=90
+
+FLAG=/etc/tollgate_timesynced
+
+start() {
+    [ -f "$FLAG" ] && exit 0
+
+    (
+        SERVERS=$(uci -q get system.ntp.server | tr ' ' '\n' | grep -v '^$')
+        [ -z "$SERVERS" ] && SERVERS="0.openwrt.pool.ntp.org 1.openwrt.pool.ntp.org"
+        NTP_ARGS=""
+        for s in $SERVERS; do NTP_ARGS="$NTP_ARGS -p $s"; done
+
+        while true; do
+            if ntpd -q -n $NTP_ARGS >/dev/null 2>&1; then
+                touch "$FLAG"
+                logger -t tollgate-timesync "clock synced at $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+                exit 0
+            fi
+            logger -t tollgate-timesync "sync failed, retrying in 30s"
+            sleep 30
+        done
+    ) &
+}

--- a/files/etc/rc.d/S45tollgate-timesync
+++ b/files/etc/rc.d/S45tollgate-timesync
@@ -1,0 +1,1 @@
+../init.d/tollgate-timesync


### PR DESCRIPTION
## Summary
New init.d service `tollgate-timesync` that retries `ntpd -q` in the background until one successful sync ever, then marks `/etc/tollgate_timesynced` and stays a no-op on subsequent boots.

## Why
On fresh flashes, OpenWrt's `sysfixtime` sets the clock to the firmware build date. Until `sysntpd`'s async catch-up completes, Cashu token validation fails and the wallet can't start. Landing this at the OS level so every TollGate-OS flash gets it, rather than only routers that install the basic-go package on a pre-existing system.

Fixes [OpenTollGate/tollgate-module-basic-go#42](https://github.com/OpenTollGate/tollgate-module-basic-go/issues/42).

## Design
- Persistent flag in `/etc`: a router that couldn't sync at first boot will resume trying on reboot.
- Background child so `start()` returns quickly and doesn't block boot.
- Falls back to `0./1.openwrt.pool.ntp.org` if `system.ntp.server` is empty.
- 30 s retry interval to avoid hammering pools on long offline windows.

## Test plan
- [ ] Fresh flash with internet available → clock syncs within 30 s, flag created.
- [ ] Fresh flash with no internet → loop logs failures; reconnect → next attempt succeeds, flag created.
- [ ] Reboot an established router (flag present) → service exits immediately.