### PR TITLE
refactor(firstboot): move random-lan-ip from basic-go pkg to OS

### DIFF
--- a/files/etc/uci-defaults/95-random-lan-ip
+++ b/files/etc/uci-defaults/95-random-lan-ip
@@ -1,22 +1,23 @@
 #!/bin/sh
 # TollGate - Generate random LAN IP address on first boot
 
-FLAG_FILE="/etc/tollgate/firstboot/lan_ip_randomized"
+FLAG_FILE="/etc/config/95-random-lan-ip.done"
+
+# Check if the script has already been executed
 if [ -f "$FLAG_FILE" ]; then
-    echo "LAN IP already randomized. Exiting."
+    echo "95-random-lan-ip already executed. Exiting."
     exit 0
 fi
 
-INSTALL_JSON="/etc/tollgate/install.json"
-if [ -f "$INSTALL_JSON" ]; then
-    IP_RANDOMIZED=$(jq -r '.ip_address_randomized' "$INSTALL_JSON")
-    if [ "$IP_RANDOMIZED" != "false" ]; then
-        echo "IP is already randomized or not set to false. Exiting."
-        exit 0
-    fi
-else
-    echo "install.json not found. Exiting."
-    exit 1
+# Check current LAN IP address
+CURRENT_IP=$(uci -q get network.lan.ipaddr)
+
+# If IP is already randomized (not 192.168.1.1), exit
+if [ "$CURRENT_IP" != "192.168.1.1" ]; then
+    echo "IP is already randomized to $CURRENT_IP. Exiting."
+    # Create flag file even if IP is already randomized, to prevent future runs
+    touch "$FLAG_FILE"
+    exit 0
 fi
 
 # Helper function to safely set UCI values with error handling
@@ -50,40 +51,45 @@ uci_safe_set() {
     uci set "$config.$section.$option=$value" >/dev/null 2>&1
 }
 
-# Initialize random seed
-RANDOM=$$$(date +%s)
+# Read an unsigned integer from /dev/urandom. $$ + date-based $RANDOM is
+# nearly identical across devices on first boot (no RTC, no NTP), so we
+# draw entropy from the kernel pool instead.
+rand_u16() {
+    hexdump -n 2 -e '"%u"' /dev/urandom
+}
 
 # Randomly select one of the three private IP ranges:
 # 1: 10.0.0.0/8
 # 2: 172.16.0.0/12
 # 3: 192.168.0.0/16
-RANGE_SELECT=$((RANDOM % 3 + 1))
+RANGE_SELECT=$(( $(rand_u16) % 3 + 1 ))
 
 case $RANGE_SELECT in
     1)
         # 10.0.0.0/8 range
         OCTET1=10
-        OCTET2=$((1 + RANDOM % 254))  # 1-254
-        OCTET3=$((1 + RANDOM % 254))  # 1-254
+        OCTET2=$(( $(rand_u16) % 254 + 1 ))  # 1-254
+        OCTET3=$(( $(rand_u16) % 254 + 1 ))  # 1-254
         ;;
     2)
         # 172.16.0.0/12 range (172.16.x.x - 172.31.x.x)
         OCTET1=172
-        OCTET2=$((RANDOM % 16 + 16))  # 16-31
-        OCTET3=$((RANDOM % 256))
+        OCTET2=$(( $(rand_u16) % 16 + 16 ))  # 16-31
+        OCTET3=$(( $(rand_u16) % 256 ))
         ;;
     3)
         # 192.168.0.0/16 range
         OCTET1=192
         OCTET2=168
-        OCTET3=$((RANDOM % 256))
+        OCTET3=$(( $(rand_u16) % 256 ))
         ;;
 esac
 
 # Avoid common third octets in the 192.168.x.x range to reduce conflicts
 if [ $OCTET1 -eq 192 ] && [ $OCTET2 -eq 168 ]; then
+    # Avoid common values like 0, 1, 100
     while [ $OCTET3 -eq 0 ] || [ $OCTET3 -eq 1 ] || [ $OCTET3 -eq 100 ]; do
-        OCTET3=$((RANDOM % 256))
+        OCTET3=$(( $(rand_u16) % 256 ))
     done
 fi
 
@@ -97,14 +103,20 @@ uci commit network
 
 # Update hosts file
 if grep -q "status.client" /etc/hosts; then
+    # Replace existing entry
     sed -i "s/.*status\.client/$RANDOM_IP status.client/" /etc/hosts
 else
+    # Add new entry
     echo "$RANDOM_IP status.client" >> /etc/hosts
 fi
 
 # NoDogSplash config check and update (only if installed)
 if [ -f "/etc/config/nodogsplash" ]; then
     if uci -q get nodogsplash.@nodogsplash[0] >/dev/null; then
+        # statuspath is typically a URI path, not an IP
+        # If you need to set it to a full URL:
+        # uci set nodogsplash.@nodogsplash[0].statuspath="http://$RANDOM_IP/status"
+        # uci commit nodogsplash
         echo "NoDogSplash detected, would update its config if needed"
     fi
 fi
@@ -112,19 +124,16 @@ fi
 # Also update the default gateway and broadcast address accordingly
 NETMASK="255.255.255.0"  # Using standard /24 subnet
 uci_safe_set network lan netmask "$NETMASK"
-
+ 
 # Calculate subnet information for correct operation
+# For a /24 network, the broadcast is always x.y.z.255
 BROADCAST="$OCTET1.$OCTET2.$OCTET3.255"
 uci_safe_set network lan broadcast "$BROADCAST"
 
-# Schedule network restart (safer than immediate restart during boot)
-(sleep 5 && /etc/init.d/network restart && 
- [ -f "/etc/init.d/nodogsplash" ] && /etc/init.d/nodogsplash restart) &
-
-# Update install.json with the new random IP
-jq '.ip_address_randomized = "'"$RANDOM_IP"'"' "$INSTALL_JSON" > "$INSTALL_JSON.tmp" && mv "$INSTALL_JSON.tmp" "$INSTALL_JSON"
-
-# Create flag file
+# Create flag file to indicate script has been executed
 touch "$FLAG_FILE"
 
-exit 0
+# No reboot needed: the committed LAN IP is picked up by the
+# `service network reload` at the end of 99b-tollgate-setup-private-ssid.
+# A reboot here previously raced with 99a/99b, killing them mid-run and
+# forcing them to re-execute on the next boot.


### PR DESCRIPTION
## Summary
Promotes the random-LAN-IP first-boot script from the basic-go package into tollgate-os, and removes the orphaned copy under `firstboot.d/`.

## Why
Two copies exist today: the active one in [basic-go](https://github.com/OpenTollGate/tollgate-module-basic-go/blob/main/files/etc/uci-defaults/95-random-lan-ip), and a stale one here under `files/etc/tollgate/firstboot.d/` that has no caller in the OS repo. Moving the feature to the OS so fresh flashes always get a randomized LAN IP regardless of package selection, and deleting the dead code. Companion PR removes the pkg copy: [OpenTollGate/tollgate-module-basic-go#96](https://github.com/OpenTollGate/tollgate-module-basic-go/pull/96).

## Test plan
- [ ] Fresh flash → LAN IP is randomized away from 192.168.1.1 on first boot.
- [ ] Reflash with same random IP already present → script no-ops via its flag file.