### PR TITLE
fix(publish-os): filter Nostr package fetch to format=ipk

### DIFF
--- a/.github/workflows/publish-os.yml
+++ b/.github/workflows/publish-os.yml
@@ -320,13 +320,24 @@ jobs:
             exit 1
           fi
           
-          # Filter by compression type (compression tag is not filterable in nak)
-          FILTERED_EVENTS=$(echo "$EVENTS" | jq --arg comp "$PACKAGE_COMPRESSION" '[.[] | select(.tags[] | select(.[0] == "compression" and .[1] == $comp))]')
-          
+          # Post-receive filter for compression and format. Nostr relays
+          # only index single-letter tag names (NIP-01) so 'compression'
+          # and 'format' must be filtered client-side. format=ipk is
+          # required because the basic-go pipeline now publishes both .ipk
+          # and .apk events for the same (arch, compression); the OpenWrt
+          # 24.x image builder used here consumes .ipk only, so without
+          # the filter the first matching event may be an .apk and the
+          # downstream 'extract package name' step fails.
+          FILTERED_EVENTS=$(echo "$EVENTS" | jq --arg comp "$PACKAGE_COMPRESSION" '
+            [ .[] |
+              select(.tags[] | select(.[0] == "compression" and .[1] == $comp)) |
+              select(.tags[] | select(.[0] == "format" and .[1] == "ipk"))
+            ]')
+
           if [ "$(echo "$FILTERED_EVENTS" | jq 'length')" -eq 0 ]; then
-            echo "❌ No package found with compression type: $PACKAGE_COMPRESSION"
-            echo "ℹ️ Available packages:"
-            echo "$EVENTS" | jq -r '.[] | .tags[] | select(.[0] == "compression") | "  - \(.[1])"' | sort -u
+            echo "❌ No .ipk package found with compression type: $PACKAGE_COMPRESSION"
+            echo "ℹ️ Available (compression, format) pairs for this version+arch:"
+            echo "$EVENTS" | jq -r '.[] | [(.tags[] | select(.[0] == "compression") | .[1]), (.tags[] | select(.[0] == "format") | .[1]) // "unknown"] | "  - \(.[0]) (\(.[1]))"' | sort -u
             exit 1
           fi
           


### PR DESCRIPTION
## Summary

The basic-go pipeline now publishes both `.ipk` (OpenWrt ≤ 24.10) and `.apk` (OpenWrt 25.x) NIP-94 events for the same `(architecture, compression)` tuple. The Nostr query in [`publish-os.yml:308-313`](.github/workflows/publish-os.yml#L308-L313) matches on `(author, n, v, A)` and the post-receive jq filter previously only checked `compression` — so when both formats existed for the same combo, the first matching event could be the `.apk`. The OpenWrt-24 image builder only consumes `.ipk`, so the next step silently failed with:

```
⚠️  Could not extract package name from tollgate-wrt_98-merge.72.a100388_mips_24kc-upx-ultra-brute.apk
❌ No valid packages found in ./custom-packages
```

Filtering for `format == "ipk"` in the same client-side jq pass fixes it. Done client-side because Nostr relays don't index multi-letter tag names (NIP-01), so a relay-side `--tag format=ipk` would be silently ignored.

The "available packages" diagnostic also now prints `(compression, format)` pairs instead of just compression, which makes this class of mismatch easier to spot in future logs.

## Test plan

- [ ] Trigger an OS build on `main` after merging the basic-go perf PR — confirm the fetched package is `.ipk` and the build proceeds past the inspect step.