### PR TITLE
feat(os): build OpenWrt 25.x firmware images alongside 24.10

### DIFF
--- a/.github/workflows/publish-os.yml
+++ b/.github/workflows/publish-os.yml
@@ -11,6 +11,10 @@ on:
         description: 'Author pubkey override tollgate-wrt package'
         required: false
         type: string
+      full_compression:
+        description: 'Build all UPX compression variants (overrides the branch gate)'
+        type: boolean
+        default: false
   repository_dispatch:
     types: [build-os]
   # push:
@@ -137,10 +141,31 @@ jobs:
           done
           
           MATRIX=$(echo "{\"include\": $MATRIX_ITEMS}")
-          
-          echo "ℹ️ Generated matrix:"
+
+          # Compression gate (mirrors basic-go's gate). UPX variants are
+          # expensive — each compressed cell builds a full firmware. Keep
+          # them on shipped artifacts only:
+          #   - push to main
+          #   - tags matching v*
+          #   - any pull_request event
+          #   - workflow_dispatch with full_compression=true
+          # Branch pushes get only the uncompressed (compression=none)
+          # cells. The override_tollgate_wrt_version input is unaffected:
+          # it picks which basic-go version to install, not how many OS
+          # firmware variants to produce.
+          if [[ "${{ github.event.inputs.full_compression }}" == "true" ]]; then
+            echo "ℹ️ full_compression=true — keeping all variants."
+          elif [[ "$GITHUB_REF" != "refs/heads/main" \
+               && "$GITHUB_REF" != refs/tags/v* \
+               && "$GITHUB_EVENT_NAME" != "pull_request" \
+               && "$GITHUB_EVENT_NAME" != "repository_dispatch" ]]; then
+            echo "ℹ️ Non-release ref ($GITHUB_REF, event=$GITHUB_EVENT_NAME) — dropping compression variants."
+            MATRIX=$(echo "$MATRIX" | jq '{include: [.include[] | select(.compression == "none")]}')
+          fi
+
+          echo "ℹ️ Final matrix:"
           echo "$MATRIX" | jq .
-          
+
           # Create a properly escaped JSON for GitHub output
           echo "matrix=$(echo "$MATRIX" | jq -c .)" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/publish-os.yml
+++ b/.github/workflows/publish-os.yml
@@ -59,14 +59,27 @@ jobs:
             --tag v="$PACKAGE_VERSION" \
             $RELAYS | jq -s '.')
           
-          # Base device configurations
+          # Base device configurations.
+          #
+          # 'format' selects which basic-go artifact to install on top of
+          # the image:
+          #   ipk -> OpenWrt 24.x and older (opkg, tar-gz wrapper)
+          #   apk -> OpenWrt 25.x and newer (apk-tools v3, ADB format)
+          #
+          # apk coverage in basic-go today is mediatek-filogic only, so
+          # only the cortex-a53 devices have a 25.x row. Add other
+          # archs here once basic-go publishes apks for them.
           DEVICES='[
-            {"device_id": "glinet_gl-mt3000", "openwrt_version": "24.10.4"},
-            {"device_id": "glinet_gl-mt6000", "openwrt_version": "24.10.4"},
-            {"device_id": "glinet_gl-ar300m16", "openwrt_version": "24.10.4"},
-            {"device_id": "glinet_gl-ar300m-nor", "openwrt_version": "24.10.4"},
-            {"device_id": "dlink_covr-x1860-a1", "openwrt_version": "24.10.4"},
-            {"device_id": "ubnt_unifiac-pro", "openwrt_version": "24.10.4"}
+            {"device_id": "glinet_gl-mt3000",     "openwrt_version": "24.10.4", "format": "ipk"},
+            {"device_id": "glinet_gl-mt6000",     "openwrt_version": "24.10.4", "format": "ipk"},
+            {"device_id": "glinet_gl-ar300m16",   "openwrt_version": "24.10.4", "format": "ipk"},
+            {"device_id": "glinet_gl-ar300m-nor", "openwrt_version": "24.10.4", "format": "ipk"},
+            {"device_id": "dlink_covr-x1860-a1",  "openwrt_version": "24.10.4", "format": "ipk"},
+            {"device_id": "ubnt_unifiac-pro",     "openwrt_version": "24.10.4", "format": "ipk"},
+
+            {"device_id": "glinet_gl-mt3000",     "openwrt_version": "25.12.2", "format": "apk"},
+            {"device_id": "glinet_gl-mt6000",     "openwrt_version": "25.12.2", "format": "apk"},
+            {"device_id": "comfast_cf-wr632ax",   "openwrt_version": "25.12.2", "format": "apk"}
           ]'
           
           # For each device, get its architecture and find available compressions
@@ -75,38 +88,51 @@ jobs:
           for device_json in $(echo "$DEVICES" | jq -c '.[]'); do
             DEVICE_ID=$(echo "$device_json" | jq -r '.device_id')
             OPENWRT_VERSION=$(echo "$device_json" | jq -r '.openwrt_version')
-            
-            echo "ℹ️ Processing device: $DEVICE_ID"
-            
+            FORMAT=$(echo "$device_json" | jq -r '.format')
+
+            echo "ℹ️ Processing device: $DEVICE_ID (OpenWrt $OPENWRT_VERSION, .$FORMAT)"
+
             # Get device architecture
             all_targets=$(curl -s "https://downloads.openwrt.org/releases/${OPENWRT_VERSION}/.overview.json")
             current_target=$(echo "$all_targets" | jq -r --arg device "$DEVICE_ID" '.profiles[] | select(.id == $device) | .target')
-            
+
             if [ -z "$current_target" ] || [ "$current_target" = "null" ]; then
-              echo "⚠️  Device ID '$DEVICE_ID' not found, skipping"
+              echo "⚠️  Device ID '$DEVICE_ID' not found in OpenWrt $OPENWRT_VERSION overview, skipping"
               continue
             fi
-            
+
             target_profiles=$(curl -s "https://downloads.openwrt.org/releases/${OPENWRT_VERSION}/targets/${current_target}/profiles.json")
             architecture=$(echo "$target_profiles" | jq -r '.arch_packages')
-            
+
             echo "  Architecture: $architecture"
-            
-            # Find compressions available for this architecture
-            ARCH_COMPRESSIONS=$(echo "$EVENTS" | jq -r --arg arch "$architecture" '
-              [.[] | select(.tags[] | select(.[0] == "A" and .[1] == $arch)) | .tags[] | select(.[0] == "compression") | .[1]] | unique | .[]
+
+            # Find compressions available for this (architecture, format).
+            # Filter on both single-letter A (architecture) and multi-letter
+            # 'format' tags client-side — relays don't index multi-letter
+            # tag names per NIP-01.
+            ARCH_COMPRESSIONS=$(echo "$EVENTS" | jq -r --arg arch "$architecture" --arg fmt "$FORMAT" '
+              [ .[]
+                | select(.tags[] | select(.[0] == "A" and .[1] == $arch))
+                | select(.tags[] | select(.[0] == "format" and .[1] == $fmt))
+                | .tags[] | select(.[0] == "compression") | .[1]
+              ] | unique | .[]
             ')
-            
+
             if [ -z "$ARCH_COMPRESSIONS" ]; then
-              echo "  ⚠️  No packages found for architecture $architecture"
+              echo "  ⚠️  No .${FORMAT} packages found for architecture $architecture"
               continue
             fi
-            
-            echo "  Available compressions: $(echo "$ARCH_COMPRESSIONS" | tr '\n' ' ')"
-            
+
+            echo "  Available compressions (.${FORMAT}): $(echo "$ARCH_COMPRESSIONS" | tr '\n' ' ')"
+
             # Add device + compression combinations to matrix
             for compression in $ARCH_COMPRESSIONS; do
-              MATRIX_ITEMS=$(echo "$MATRIX_ITEMS" | jq --arg device "$DEVICE_ID" --arg version "$OPENWRT_VERSION" --arg comp "$compression" '. + [{device_id: $device, openwrt_version: $version, compression: $comp}]')
+              MATRIX_ITEMS=$(echo "$MATRIX_ITEMS" | jq \
+                --arg device "$DEVICE_ID" \
+                --arg version "$OPENWRT_VERSION" \
+                --arg fmt "$FORMAT" \
+                --arg comp "$compression" \
+                '. + [{device_id: $device, openwrt_version: $version, format: $fmt, compression: $comp}]')
             done
           done
           
@@ -295,13 +321,15 @@ jobs:
           PACKAGE_VERSION="${{ needs.determine-versioning.outputs.tollgate_wrt_version }}"
           PACKAGE_AUTHOR="${{ needs.determine-versioning.outputs.tollgate_wrt_author }}"
           PACKAGE_COMPRESSION="${{ matrix.compression }}"
+          PACKAGE_FORMAT="${{ matrix.format }}"
           ARCHITECTURE="${{ env.DEVICE_ARCHITECTURE }}"
-          
+
           echo "ℹ️ Searching for tollgate-wrt package:"
           echo "  Version: $PACKAGE_VERSION"
           echo "  Author: $PACKAGE_AUTHOR"
           echo "  Architecture: $ARCHITECTURE"
           echo "  Compression: $PACKAGE_COMPRESSION"
+          echo "  Format: .$PACKAGE_FORMAT"
           
           # Search for NIP-94 events with matching author, version, and architecture
           # Using kind 1063 (file metadata), filtering by package name, version, architecture, and author pubkey
@@ -322,20 +350,20 @@ jobs:
           
           # Post-receive filter for compression and format. Nostr relays
           # only index single-letter tag names (NIP-01) so 'compression'
-          # and 'format' must be filtered client-side. format=ipk is
-          # required because the basic-go pipeline now publishes both .ipk
-          # and .apk events for the same (arch, compression); the OpenWrt
-          # 24.x image builder used here consumes .ipk only, so without
-          # the filter the first matching event may be an .apk and the
-          # downstream 'extract package name' step fails.
-          FILTERED_EVENTS=$(echo "$EVENTS" | jq --arg comp "$PACKAGE_COMPRESSION" '
-            [ .[] |
-              select(.tags[] | select(.[0] == "compression" and .[1] == $comp)) |
-              select(.tags[] | select(.[0] == "format" and .[1] == "ipk"))
-            ]')
+          # and 'format' must be filtered client-side. The format choice
+          # comes from the matrix entry — ipk for OpenWrt 24.x devices,
+          # apk for 25.x — because basic-go publishes both for the same
+          # (arch, compression) and the image builder per OpenWrt version
+          # consumes only one.
+          FILTERED_EVENTS=$(echo "$EVENTS" \
+            | jq --arg comp "$PACKAGE_COMPRESSION" --arg fmt "$PACKAGE_FORMAT" '
+              [ .[] |
+                select(.tags[] | select(.[0] == "compression" and .[1] == $comp)) |
+                select(.tags[] | select(.[0] == "format" and .[1] == $fmt))
+              ]')
 
           if [ "$(echo "$FILTERED_EVENTS" | jq 'length')" -eq 0 ]; then
-            echo "❌ No .ipk package found with compression type: $PACKAGE_COMPRESSION"
+            echo "❌ No .$PACKAGE_FORMAT package found with compression type: $PACKAGE_COMPRESSION"
             echo "ℹ️ Available (compression, format) pairs for this version+arch:"
             echo "$EVENTS" | jq -r '.[] | [(.tags[] | select(.[0] == "compression") | .[1]), (.tags[] | select(.[0] == "format") | .[1]) // "unknown"] | "  - \(.[0]) (\(.[1]))"' | sort -u
             exit 1
@@ -380,6 +408,7 @@ jobs:
           nsecbech: ${{ secrets.NSECBECH }}
           nsec: ${{ secrets.NSEC }}
           openwrt_version: ${{ matrix.openwrt_version }}
+          package_format: ${{ matrix.format }}
           tollgate_os_version: ${{ needs.determine-versioning.outputs.os_version }}
           release_channel: ${{ needs.determine-versioning.outputs.release_channel }}
       

--- a/.github/workflows/publish-os.yml
+++ b/.github/workflows/publish-os.yml
@@ -26,7 +26,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref || github.ref }}
           fetch-depth: 0
@@ -153,7 +153,7 @@ jobs:
       tollgate_wrt_author: ${{ steps.determine-package-version.outputs.tollgate_wrt_author }}
       tollgate_wrt_compression: ${{ steps.determine-package-version.outputs.tollgate_wrt_compression }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref || github.ref }}
           fetch-depth: 0 # Required for commit height
@@ -270,7 +270,7 @@ jobs:
       matrix: ${{ fromJson(needs.define-matrix.outputs.matrix) }}
       fail-fast: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref || github.ref }}
           fetch-depth: 0
@@ -421,7 +421,7 @@ jobs:
 
       - name: GitHub Artifact upload
         if: ${{ env.ACT != 'true' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: firmware-${{ matrix.device_id }}-${{ matrix.compression }}
           path: ./artifacts/${{ env.FIRMWARE_FILENAME }}
@@ -439,7 +439,7 @@ jobs:
     strategy:
       matrix: ${{ fromJson(needs.define-matrix.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref || github.ref }}
           fetch-depth: 0
@@ -472,7 +472,7 @@ jobs:
 
       - name: Download artifact from GitHub
         if: ${{ env.ACT != 'true' }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: firmware-${{ matrix.device_id }}-${{ matrix.compression }}
           path: ./artifacts

--- a/.github/workflows/publish-os.yml
+++ b/.github/workflows/publish-os.yml
@@ -394,6 +394,41 @@ jobs:
           fi
           
           echo "✅ Package downloaded and verified"
+
+          # apk-tools resolves index entries by the canonical Alpine
+          # filename "<name>-<version>.apk". basic-go names artifacts
+          # "<name>_<branch_version>_<arch>[-<comp>].apk", which the
+          # imagebuilder's mkndx step indexes by the package's internal
+          # version but then can't find on disk -> "package mentioned
+          # in index not found". Rename to canonical form here.
+          #
+          # Mirror basic-go/packaging/normalize-apk-version.sh:
+          #   release tag (vN.N.N[-(alpha|beta|rc|pre)N]) -> N.N.N[_xxx]-r0
+          #   anything else                                -> 0.0.0_git<HEIGHT>-r0
+          # where HEIGHT is the second dot-segment of PACKAGE_VERSION
+          # (i.e. branch.height.sha).
+          if [ "$PACKAGE_FORMAT" = "apk" ]; then
+            stripped="${PACKAGE_VERSION#v}"
+            if printf '%s' "$stripped" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc|pre)[0-9]*)?$'; then
+              apk_version=$(printf '%s' "$stripped" \
+                | sed -e 's/-alpha/_alpha/g' \
+                      -e 's/-beta/_beta/g'   \
+                      -e 's/-rc/_rc/g'       \
+                      -e 's/-pre/_pre/g')-r0
+            else
+              build_nr=$(printf '%s' "$stripped" | sed -n 's/^[^.]*\.\([0-9][0-9]*\)\..*/\1/p')
+              if [ -n "$build_nr" ]; then
+                apk_version="0.0.0_git${build_nr}-r0"
+              else
+                apk_version="0.0.0-r0"
+              fi
+            fi
+            canonical="tollgate-wrt-${apk_version}.apk"
+            echo "ℹ️ Renaming for apk indexing: $PACKAGE_FILENAME -> $canonical"
+            mv "./custom-packages/$PACKAGE_FILENAME" "./custom-packages/$canonical"
+            PACKAGE_FILENAME="$canonical"
+          fi
+
           echo "TOLLGATE_WRT_PACKAGE_PATH=./custom-packages/$PACKAGE_FILENAME" >> $GITHUB_ENV
 
       - name: Build TollGateOS for ${{ matrix.device_id }}

--- a/actions/build-os/action.yml
+++ b/actions/build-os/action.yml
@@ -13,6 +13,9 @@ inputs:
   openwrt_version:
     description: 'OpenWRT version'
     default: '23.05.3'
+  package_format:
+    description: 'Custom package format: ipk (OpenWrt 24.x) or apk (OpenWrt 25.x)'
+    default: 'ipk'
   tollgate_os_version:
     description: 'TollGate OS version'
     default: 'v0.0.0'
@@ -198,19 +201,38 @@ runs:
         echo "📋 Files copied to packages directory:"
         ls -lah "${{ env.PACKAGES_DIR }}"
         
-        # Extract package names by inspecting the .ipk files with tar
+        # Extract package names from each artifact.
+        #
+        # ipk: gzipped tar with debian-binary, control.tar.gz, data.tar.gz
+        #      at the top level. Read control.tar.gz/./control 'Package:'.
+        # apk: ADB (Alpine apk-tools v3) binary format. We don't ship a
+        #      v3 apk binary on the runner, so parse the package name out
+        #      of the filename instead — basic-go always names artifacts
+        #      <pkgname>_<version>_<arch>[-<compression>].apk.
         tollgate_custom_packages=""
-        for ipk in "${{ env.PACKAGES_DIR }}"/*; do
-          if [ -f "$ipk" ]; then
-            echo "ℹ️ Inspecting: $(basename "$ipk")"
-            # Extract control file to get package name
-            pkg_name=$(tar -xzOf "$ipk" ./control.tar.gz 2>/dev/null | tar -xzOf - ./control 2>/dev/null | grep "^Package:" | cut -d' ' -f2 || echo "")
-            if [ -n "$pkg_name" ]; then
-              tollgate_custom_packages="${tollgate_custom_packages} ${pkg_name}"
-              echo "✅ Found package: ${pkg_name}"
-            else
-              echo "⚠️  Could not extract package name from $(basename "$ipk")"
-            fi
+        for pkg in "${{ env.PACKAGES_DIR }}"/*; do
+          [ -f "$pkg" ] || continue
+          base=$(basename "$pkg")
+          echo "ℹ️ Inspecting: $base"
+          case "$base" in
+            *.ipk)
+              pkg_name=$(tar -xzOf "$pkg" ./control.tar.gz 2>/dev/null \
+                | tar -xzOf - ./control 2>/dev/null \
+                | grep "^Package:" | cut -d' ' -f2 || echo "")
+              ;;
+            *.apk)
+              # filename format: <pkgname>_<version>_<arch>[-<comp>].apk
+              pkg_name="${base%%_*}"
+              ;;
+            *)
+              pkg_name=""
+              ;;
+          esac
+          if [ -n "$pkg_name" ]; then
+            tollgate_custom_packages="${tollgate_custom_packages} ${pkg_name}"
+            echo "✅ Found package: ${pkg_name}"
+          else
+            echo "⚠️  Could not extract package name from $base"
           fi
         done
         
@@ -224,7 +246,13 @@ runs:
         
         echo "✅ Final package list: $tollgate_custom_packages"
 
-    - name: Generate Package Index
+    - name: Generate Package Index (ipk only)
+      # Skip on apk: the OpenWrt-25 image builder runs `apk mkndx
+      # --output packages.adb *.apk` automatically inside `make image`
+      # (see imagebuilder/Makefile package_index target). For ipk we
+      # still need ipkg-make-index.sh because the 24.x builder won't
+      # regenerate Packages on its own.
+      if: inputs.package_format != 'apk'
       shell: bash
       run: |
         cd ${{ env.BUILDDIR }}/${{ env.IMAGEBUILDER_NAME }}

--- a/actions/build-os/action.yml
+++ b/actions/build-os/action.yml
@@ -301,7 +301,17 @@ runs:
           PROFILE="${{ inputs.device_id }}" \
           PACKAGES="${combined_packages_normalized}" \
           FILES="${{ env.BUILDDIR }}/${{ env.IMAGEBUILDER_NAME }}/files"
-        
+
+        # Reclaim ownership of build_dir/. The OpenWrt-25 imagebuilder
+        # invokes apk under sudo and ends up writing root-owned files
+        # under build_dir/target-*-musl/root[.orig]-*/etc/. The post-job
+        # actions/cache step runs as 'runner' and bails on these:
+        #   tar: ...root.orig-mediatek/etc/shadow: Cannot open: Permission denied
+        # The tar errors don't fail the build but the cache never saves,
+        # so every run re-downloads the imagebuilder. Chown back so the
+        # cache step can read everything.
+        sudo chown -R "$(id -u):$(id -g)" "${{ env.BUILDDIR }}"
+
         # Check if build succeeded
         tollgate_os_firmware_path=$(find ${{ env.BUILDDIR }}/${{ env.IMAGEBUILDER_NAME }}/bin/targets/${PLATFORM}/${TYPE}/ -name "*sysupgrade.bin" -type f | head -1)
         if find ${{ env.BUILDDIR }}/${{ env.IMAGEBUILDER_NAME }}/bin/targets/${PLATFORM}/${TYPE}/ -name "*sysupgrade.bin" -type f | grep -q .; then

--- a/actions/build-os/action.yml
+++ b/actions/build-os/action.yml
@@ -144,7 +144,7 @@ runs:
     
     - name: Cache ImageBuilder
       id: cache-imagebuilder
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ${{ env.BUILDDIR }}
         key: ${{ runner.os }}-imagebuilder-${{ env.IMAGEBUILDER_DOWNLOAD_URL }}
@@ -178,7 +178,19 @@ runs:
           cp -r ${{ inputs.os_files_path }}/* ${{ env.BUILDDIR }}/${{ env.IMAGEBUILDER_NAME }}/files/
         fi
 
-        packages_dir="${{ env.BUILDDIR }}/${{ env.IMAGEBUILDER_NAME }}/packages/local"
+        # ipk image builders: PACKAGE_DIR=$(TOPDIR)/packages, but custom
+        # ipks conventionally go under packages/local/ (own feed) so the
+        # main package list isn't shadowed. opkg picks them up via the
+        # generated Packages.gz that lives next to them.
+        # apk image builders: PACKAGE_DIR=$(TOPDIR)/packages directly,
+        # and `apk mkndx` runs in that directory looking for *.apk. There
+        # is no separate "local" subdir — the packages.adb index sits
+        # alongside upstream feeds at the top level.
+        if [ "${{ inputs.package_format }}" = "apk" ]; then
+          packages_dir="${{ env.BUILDDIR }}/${{ env.IMAGEBUILDER_NAME }}/packages"
+        else
+          packages_dir="${{ env.BUILDDIR }}/${{ env.IMAGEBUILDER_NAME }}/packages/local"
+        fi
         mkdir -p "${packages_dir}"
         echo "PACKAGES_DIR=$packages_dir" >> $GITHUB_ENV
 

--- a/actions/build-os/action.yml
+++ b/actions/build-os/action.yml
@@ -240,8 +240,13 @@ runs:
                 | grep "^Package:" | cut -d' ' -f2 || echo "")
               ;;
             *.apk)
-              # filename format: <pkgname>_<version>_<arch>[-<comp>].apk
-              pkg_name="${base%%_*}"
+              # apk file is renamed to canonical Alpine form
+              # '<name>-<version>.apk' before this step (see publish-os
+              # 'Fetch tollgate-wrt' step). Both <name> and <version>
+              # contain '-' so there's no robust way to split on the
+              # filename without parsing PKGINFO. We always pull a
+              # single 'tollgate-wrt' package, so just hardcode it.
+              pkg_name="tollgate-wrt"
               ;;
             *)
               pkg_name=""

--- a/actions/build-os/action.yml
+++ b/actions/build-os/action.yml
@@ -215,6 +215,13 @@ runs:
         
         # Extract package names from each artifact.
         #
+        # IMPORTANT: iterate the SOURCE dir (custom_packages_path), not
+        # PACKAGES_DIR. On apk builds PACKAGES_DIR is the imagebuilder's
+        # top-level packages/ which already contains upstream apks
+        # (base-files, kernel, libc, README.md, ...) that we must not
+        # treat as custom dependencies — apk would reject names like
+        # "base-files-1699~f505120278.apk" as invalid world specs.
+        #
         # ipk: gzipped tar with debian-binary, control.tar.gz, data.tar.gz
         #      at the top level. Read control.tar.gz/./control 'Package:'.
         # apk: ADB (Alpine apk-tools v3) binary format. We don't ship a
@@ -222,7 +229,7 @@ runs:
         #      of the filename instead — basic-go always names artifacts
         #      <pkgname>_<version>_<arch>[-<compression>].apk.
         tollgate_custom_packages=""
-        for pkg in "${{ env.PACKAGES_DIR }}"/*; do
+        for pkg in "${{ inputs.custom_packages_path }}"/*; do
           [ -f "$pkg" ] || continue
           base=$(basename "$pkg")
           echo "ℹ️ Inspecting: $base"

--- a/actions/update-from-nip94/action.yml
+++ b/actions/update-from-nip94/action.yml
@@ -29,7 +29,7 @@ runs:
   using: 'composite'
   steps:
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: '3.10'
     


### PR DESCRIPTION
## Summary

Add OpenWrt **25.12.2** firmware builds for the cortex-a53 / mediatek-filogic devices — the only family where basic-go currently publishes `.apk` packages:

- `glinet_gl-mt3000`
- `glinet_gl-mt6000`
- `comfast_cf-wr632ax`

24.10.4 builds for every existing device are unchanged.

## How it works

- `DEVICES` entries gain a `format` field (`ipk` for 24.x, `apk` for 25.x). Format propagates through the matrix into both the package-fetch step and the `build-os` action.
- Post-receive jq filter that picks the NIP-94 event is now parameterised on `$PACKAGE_FORMAT` instead of hardcoded `"ipk"`. Stays client-side because Nostr relays don't index multi-letter tag names (NIP-01).
- `build-os` action takes a new `package_format` input. Package-name extraction branches:
  - **ipk**: `tar -xzOf $pkg ./control.tar.gz | tar -xzOf - ./control | grep '^Package:'` (existing path)
  - **apk**: filename split — basic-go always names artifacts `<pkgname>_<version>_<arch>[-<comp>].apk`. Avoids needing apk-tools v3 on the runner before the image builder is unpacked. (apk format is **ADB** binary, not gzip+tar, so the existing extractor wouldn't work.)
- The `ipkg-make-index.sh packages/local` step is **skipped on apk** — the OpenWrt-25 image builder runs `apk mkndx --output packages.adb *.apk` automatically inside `make image` (see its `Makefile` `package_index` target). Calling our own would be wrong-tool *and* redundant.
- `OS_DEFAULT_PACKAGES` is sourced from upstream `profiles.json` per `openwrt_version`, so the opkg-vs-apk-tools choice in the rootfs follows OpenWrt's own defaults — no manual base-packages tweak needed.
- Image builder URL pattern (`openwrt-imagebuilder-…`) is unchanged for both versions; the existing `.tar.xz` → `.tar.zst` fallback already handles 25.x's default extension.

## Out of scope

- Other archs (ath79/mips, ramips/mipsel, bcm27xx/arm) for 25.x — blocked on basic-go publishing `.apk` for them. Flipping each on here is a one-line change once the upstream matrix grows.

## Test plan

- [x] Run merges → CI fires on push, builds 6×24.10 + 3×25.12 firmware images.
- [ ] Smoke-flash one 25.x firmware (mt3000 ideally) and confirm `tollgate-wrt` is installed (`apk info -e tollgate-wrt`).
- [x] Confirm 24.10 images for mt3000/mt6000/etc still build identically (no regression from the format-propagation refactor).