### PR TITLE
fix(publish-os): suffix Blossom firmware URL with .bin

### DIFF
--- a/.github/workflows/publish-os.yml
+++ b/.github/workflows/publish-os.yml
@@ -606,8 +606,10 @@ jobs:
             exit 1
           fi
           
-          # Construct Blossom URL
-          BLOSSOM_URL="$BLOSSOM_SERVER/$FILE_HASH"
+          # Construct Blossom URL with .bin suffix so browsers save the
+          # firmware with the correct extension (Blossom servers ignore the
+          # suffix and resolve by sha256 hash per BUD-01).
+          BLOSSOM_URL="$BLOSSOM_SERVER/$FILE_HASH.bin"
           
           echo "url=$BLOSSOM_URL" >> $GITHUB_OUTPUT
           echo "hash=$FILE_HASH" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary

- Append \`.bin\` to the firmware Blossom URL we publish in NIP-94 events. Browsers downloading via the URL now save with the \`.bin\` extension; proxies / webservers can serve a sensible MIME hint.
- Per [BUD-01](https://github.com/hzrd149/blossom/blob/master/buds/01.md), Blossom servers resolve by sha256 and accept (ignore) any extension on the path — non-breaking, server-agnostic.
- Closes the kanban card "TollGate OS name .bin on blossom url".

## Test plan

- [ ] CI run produces a NIP-94 event whose \`url\` tag ends in \`.bin\`
- [ ] \`curl -L \$url\` downloads the firmware (Blossom server still resolves it)
- [ ] Browser "Save link as…" suggests \`<hash>.bin\` instead of an extensionless filename
- [ ] Release explorer download link still works (it uses the \`url\` tag verbatim)